### PR TITLE
[APDV-63] Back Ogarnąć CORS-y

### DIFF
--- a/.github/workflows/frontend_test.yml
+++ b/.github/workflows/frontend_test.yml
@@ -19,7 +19,8 @@ jobs:
           channel: 'dev'
     - run: flutter pub get
     - run: flutter config --enable-web
-    - run: flutter build web
+    - run: touch .env
+    - run: flutter build web  
 
   build_apk:
     name: Build Flutter (Android)
@@ -39,4 +40,5 @@ jobs:
       with:
           channel: 'dev'
     - run: flutter pub get
+    - run: touch .env
     - run: flutter build appbundle

--- a/README.md
+++ b/README.md
@@ -6,17 +6,29 @@
     - [Frontend](#frontend)
     - [Backend](#backend)
   - [Ports](#ports)
-  - [How to run with Docker](#how-to-run-with-docker)
-    - [Backend](#backend-1)
-      - [Build failed error](#build-failed-error)
+  - [Environtment files](#environtment-files)
     - [Frontend](#frontend-1)
-  - [How to run frontend web on Raspberry Pi](#how-to-run-frontend-web-on-raspberry-pi)
+  - [How tu run](#how-tu-run)
+    - [Without Docker](#without-docker)
+      - [Backend](#backend-1)
+      - [Frontend](#frontend-2)
+    - [With Docker](#with-docker)
+      - [Backend](#backend-2)
+        - [Build failed error](#build-failed-error)
+      - [Frontend](#frontend-3)
+    - [How to run frontend web on Raspberry Pi](#how-to-run-frontend-web-on-raspberry-pi)
   - [Backend API documentation](#backend-api-documentation)
   - [Add prefix to commits](#add-prefix-to-commits)
+  - [Mock Database](#mock-database)
   
 ## Technologies
 ### Frontend
 * [Flutter](https://flutter.dev/)
+* [charts_flutter](https://pub.dev/packages/charts_flutter)
+* [dio](https://pub.dev/packages/dio)
+* [provider](https://pub.dev/packages/provider)
+* [multiselect](https://pub.dev/packages/multiselect)
+* [flutter_dotenv](https://pub.dev/packages/flutter_dotenv)
 
 ### Backend
 * [Java 17](https://openjdk.java.net/projects/jdk/17/)
@@ -24,14 +36,32 @@
 * [PostgreSQL](https://www.postgresql.org/)
 * [Webflux](https://search.maven.org/artifact/org.springframework.boot/spring-boot-starter-webflux/2.6.7/jar)
 * [SpringDoc](https://springdoc.org/)
+* [Project Lombok](https://projectlombok.org/)
+* [MapStruct](https://mapstruct.org/)
 
 ## Ports
 * Backend - 5000 - http://localhost:5000
 * Database - 5432
 
-## How to run with Docker
-### Backend
-In backend root directory is placed a [docker-compose.yml](/backend/docker-compose.yml). This file specify project environment. Project can be run with IntelIJ or in terminal:
+## Environtment files
+### Frontend
+For frontend app it is needed to make `.env` file in `frontend` folder by your own. You can set up following variables
+
+```bash
+APDV_BACKEND_URL=http://localhost:5000/   # For Android Emulator use this: http://10.0.2.2:5000/
+```
+
+## How tu run
+### Without Docker
+#### Backend
+Import project to IntelIJ IDEA and start the project. Remember to run database, it can be done by going to [docker-compose.yml](/backend/docker-compose.yml) in IntellIJ and pressing start button next to `PostgreSQL`.
+
+#### Frontend
+Open the project in IntellIJ, or Android Studio, choose device and run project.
+
+### With Docker
+#### Backend
+In backend root directory is placed a [docker-compose.yml](/backend/docker-compose.yml). This file specify project environment. Project can be run with IntellIJ or in terminal:
 ```
 $ docker-compose up
 ```
@@ -41,7 +71,7 @@ $ docker-compose up --build
 ```
 Backend is now running at http://localhost:5000
 
-#### Build failed error
+##### Build failed error
 If you see something like this:
 ```
 Building apdv_backend
@@ -54,7 +84,7 @@ You have to type in your terminal:
 $ sudo chown -R $USER postgres-data  
 ```
 
-### Frontend
+#### Frontend
 Go to `frontend` folder, build the image using Dockerfile:
 ```
 $ sudo docker build . -t apdv-frontend
@@ -65,7 +95,7 @@ $ sudo docker run -p 3000:80 -d apdv-frontend
 ```
 Frontend is now running at http://localhost:3000
 
-## How to run frontend web on Raspberry Pi
+### How to run frontend web on Raspberry Pi
 First things first you need to go to `frontend` folder and build flutter web app
 ```
 $ flutter build web
@@ -89,3 +119,6 @@ In folder `.githooks` there is a script, that automatically add prefix to commit
 ```
 $ git config --local core.hooksPath .githooks/
 ```
+
+## Mock Database
+For this moment, it is prepared a [mock.sql](/backend/sql_mocks/mock.sql) file, which can be used for testing. This script needs to be run in database manually.

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/configs/WebClientConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/configs/WebClientConfig.java
@@ -26,7 +26,7 @@ public class WebClientConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**").allowedOrigins("http://localhost:41519");
+                registry.addMapping("/**").allowedOrigins("*");
             }
         };
     }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/configs/WebClientConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/configs/WebClientConfig.java
@@ -26,6 +26,7 @@ public class WebClientConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
+                // TODO: Properly set up CORS policy, now allows everything
                 registry.addMapping("/**").allowedOrigins("*");
             }
         };

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -44,3 +44,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+*.env

--- a/frontend/lib/Repository/URLs.dart
+++ b/frontend/lib/Repository/URLs.dart
@@ -1,3 +1,5 @@
-const backendURL = 'http://localhost:5000/';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+final backendURL = dotenv.env['APDV_BACKEND_URL'] ?? 'http://localhost:5000/';     // For Android Emulator use: 'http://10.0.2.2:5000/'
 const getDataSummaryURL = 'sensor/list';
 const getEndpointDataURL= 'sensor';

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -2,12 +2,11 @@ import 'package:adpv_frontend/Repository/MockRepository.dart';
 import 'package:adpv_frontend/Repository/RestClient.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'App.dart';
-import 'Providers/CompareEndpointsModel.dart';
 
-void main() {
+Future main() async {
+  await loadEnvFile();
   runApp(MyApp());
 }
 
@@ -29,4 +28,8 @@ class MyApp extends StatelessWidget {
         ),
     );
   }
+}
+
+Future loadEnvFile() async {
+  await dotenv.load(fileName: ".env");
 }

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -83,6 +83,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -129,7 +136,7 @@ packages:
       name: loading_animation_widget
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0+1"
+    version: "1.2.0+2"
   logging:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   http: ^0.13.4
   provider: ^6.0.0
   multiselect: ^0.0.4
+  flutter_dotenv: ^5.0.2
 
 dev_dependencies:
   flutter_test:
@@ -67,6 +68,9 @@ flutter:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
+
+  assets:
+    - .env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.


### PR DESCRIPTION
- Zmieniłem politykę CORS, żeby akceptowała żądania z dowolnego URL'a. Nie jest to bezpieczne, ale na ten moment, skoro jeszcze nie mamy deploy'a, to można to tak zostawić, w przyszłości to się zmieni,
- Dodałem obsługę zmiennych środowiskowych do frontendu, dzięki temu będzie można niektóre rzeczy łatwiej ustawiać,
- Żeby z emulatora Androida można było połączyć się do backu, to trzeba ustawić adres: `http://10.0.2.2:5000/`. Ustawia się go poprzez plik `.env`, info w README. Zalecam zrobić sobie chociaż pusty plik `.env`, bo został dodany asset do pliku `pubspec.yaml`,
- Zrobiłem przy okazji lekki update README.