### PR TITLE
[APDV-68] Back Zmiana modelu Fieldu, oraz nowe API do danych z endpointa

### DIFF
--- a/backend/sql_mocks/mock.sql
+++ b/backend/sql_mocks/mock.sql
@@ -4,15 +4,20 @@ INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (59, 'AG
 INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (75, 'Ochotnica Konopnickiej', '/pl/datasets/stacje-ochotnica-21/endpoints/75/data/?limit=25');
 INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (74, 'Ochotnica Twardowskiego', '/pl/datasets/stacje-ochotnica-21/endpoints/74/data/?limit=25');
 
-INSERT INTO public.field (label) VALUES ('temperature');
-INSERT INTO public.field (label) VALUES ('pressure');
-INSERT INTO public.field (label) VALUES ('humidity');
-INSERT INTO public.field (label) VALUES ('pm1_0');
-INSERT INTO public.field (label) VALUES ('pm2_5');
-INSERT INTO public.field (label) VALUES ('pm10');
-INSERT INTO public.field (label) VALUES ('label');
-INSERT INTO public.field (label) VALUES ('id');
-INSERT INTO public.field (label) VALUES ('timestamp');
+INSERT INTO public.unit (name) VALUES ('°C');
+INSERT INTO public.unit (name) VALUES ('Pa');
+INSERT INTO public.unit (name) VALUES ('%');
+INSERT INTO public.unit (name) VALUES ('µg/m3');
+
+INSERT INTO public.field (label, field_type, unit_id) VALUES ('temperature', 0, 1);
+INSERT INTO public.field (label, field_type, unit_id) VALUES ('pressure', 0, 2);
+INSERT INTO public.field (label, field_type, unit_id) VALUES ('humidity', 0, 3);
+INSERT INTO public.field (label, field_type, unit_id) VALUES ('pm1_0', 0, 4);
+INSERT INTO public.field (label, field_type, unit_id) VALUES ('pm2_5', 0, 4);
+INSERT INTO public.field (label, field_type, unit_id) VALUES ('pm10', 0, 4);
+INSERT INTO public.field (label, field_type) VALUES ('label', 2);
+INSERT INTO public.field (label, field_type) VALUES ('id', 2);
+INSERT INTO public.field (label, field_type) VALUES ('timestamp', 2);
 
 INSERT INTO public.field_parser (path) VALUES ('/data/envSensor/temperature');
 INSERT INTO public.field_parser (path) VALUES ('/data/envSensor/pressure');

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.AddEndpointRequestBody;
+import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointSummaryResponseBody;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.UserEndpointResponseBody;
 import pl.edu.agh.apdvbackend.models.Endpoint;
@@ -37,6 +38,13 @@ public class EndpointController {
         return endpointService.getData(USER_ID, sensorId);
     }
 
+    @Operation(summary = "Get list of data from sensor that belongs to user with enable fields")
+    @GetMapping("/data")
+    public Response<EndpointData> getDataWithFields(
+            @RequestParam Long sensorId) {
+        return endpointService.getDataWithFields(USER_ID, sensorId);
+    }
+
     @Operation(summary = "Get user's endpoints list")
     @GetMapping("/list")
     public Response<List<UserEndpointResponseBody>> getUserEndpointsList() {
@@ -51,7 +59,7 @@ public class EndpointController {
 
     @Operation(summary = "Add new endpoint")
     @PostMapping
-    public Endpoint addEndpoint(
+    public Response<Endpoint> addEndpoint(
             @RequestBody AddEndpointRequestBody addEndpointRequestBody) {
         return endpointService.addEndpoint(addEndpointRequestBody);
     }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
@@ -26,10 +26,10 @@ import pl.edu.agh.apdvbackend.services.EndpointService;
 @RequiredArgsConstructor
 @Tag(name = "Endpoint")
 public class EndpointController {
+    // TODO: Remove USER_ID when JWT will be implemented
     private static final Long USER_ID = 1L;
 
     private final EndpointService endpointService;
-
 
     @Operation(summary = "Get list of data from sensor that belongs to user")
     @GetMapping

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/body_models/EndpointData.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/body_models/EndpointData.java
@@ -1,0 +1,12 @@
+package pl.edu.agh.apdvbackend.controllers.endpoint.body_models;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import pl.edu.agh.apdvbackend.models.Field;
+
+public record EndpointData(
+        @Schema(required = true) List<Field> fields,
+        @Schema(required = true) List<ObjectNode> endpointData
+) {
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/body_models/EndpointData.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/body_models/EndpointData.java
@@ -3,10 +3,10 @@ package pl.edu.agh.apdvbackend.controllers.endpoint.body_models;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import pl.edu.agh.apdvbackend.models.Field;
+import pl.edu.agh.apdvbackend.controllers.field.body_models.FieldWithoutId;
 
 public record EndpointData(
-        @Schema(required = true) List<Field> fields,
+        @Schema(required = true) List<FieldWithoutId> fields,
         @Schema(required = true) List<ObjectNode> endpointData
 ) {
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/FieldController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/FieldController.java
@@ -22,6 +22,8 @@ import pl.edu.agh.apdvbackend.services.FieldService;
 @RequiredArgsConstructor
 @Tag(name = "Field")
 public class FieldController {
+    // TODO: Remove USER_ID when JWT will be implemented
+    private static final Long USER_ID = 1L;
 
     private final FieldService fieldService;
 
@@ -36,6 +38,13 @@ public class FieldController {
     @GetMapping
     public Response<List<Field>> getAllFields() {
         return fieldService.getAllFields();
+    }
+
+    @Operation(summary = "Get list of fields, that are enable for user by endpointId")
+    @GetMapping("/enable")
+    public Response<List<Field>> getAllEnableEndpoints(
+            @RequestParam Long endpointId) {
+        return fieldService.getAllEnableEndpoints(USER_ID, endpointId);
     }
 
     @Operation(summary = "Remove field by id")

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/body_models/AddFieldBodyRequest.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/body_models/AddFieldBodyRequest.java
@@ -1,8 +1,11 @@
 package pl.edu.agh.apdvbackend.controllers.field.body_models;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import pl.edu.agh.apdvbackend.models.FieldType;
 
 public record AddFieldBodyRequest(
-        @Schema(required = true) String label
+        @Schema(required = true) String label,
+        @Schema(required = true) FieldType fieldType,
+        @Schema(required = true) String unitName
 ) {
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/body_models/FieldWithoutId.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/body_models/FieldWithoutId.java
@@ -7,6 +7,6 @@ import pl.edu.agh.apdvbackend.models.Unit;
 public record FieldWithoutId(
         @Schema(required = true) String label,
         @Schema(required = true) FieldType fieldType,
-        Unit unit
+        @Schema(required = true) Unit unit
 ) {
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/body_models/FieldWithoutId.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/field/body_models/FieldWithoutId.java
@@ -2,10 +2,11 @@ package pl.edu.agh.apdvbackend.controllers.field.body_models;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import pl.edu.agh.apdvbackend.models.FieldType;
+import pl.edu.agh.apdvbackend.models.Unit;
 
-public record AddFieldBodyRequest(
+public record FieldWithoutId(
         @Schema(required = true) String label,
         @Schema(required = true) FieldType fieldType,
-        String unitName
+        Unit unit
 ) {
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/FieldMapper.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/FieldMapper.java
@@ -1,10 +1,12 @@
 package pl.edu.agh.apdvbackend.mappers;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.springframework.beans.factory.annotation.Autowired;
 import pl.edu.agh.apdvbackend.controllers.field.body_models.AddFieldBodyRequest;
+import pl.edu.agh.apdvbackend.controllers.field.body_models.FieldWithoutId;
 import pl.edu.agh.apdvbackend.models.Field;
 import pl.edu.agh.apdvbackend.use_cases.unit.SaveUnitByNameIfNotExist;
 
@@ -27,4 +29,9 @@ public abstract class FieldMapper {
     public abstract void updateFieldFromAddRequestBody(
             AddFieldBodyRequest addFieldBodyRequest,
             @MappingTarget Field field);
+
+    public abstract FieldWithoutId fieldToWithoutId(Field field);
+
+    public abstract List<FieldWithoutId> fieldListToWithoutIdList(
+            List<Field> fields);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/FieldMapper.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/FieldMapper.java
@@ -1,14 +1,27 @@
 package pl.edu.agh.apdvbackend.mappers;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
+import org.springframework.beans.factory.annotation.Autowired;
 import pl.edu.agh.apdvbackend.controllers.field.body_models.AddFieldBodyRequest;
 import pl.edu.agh.apdvbackend.models.Field;
+import pl.edu.agh.apdvbackend.use_cases.unit.SaveUnitByNameIfNotExist;
 
 @Mapper(componentModel = "spring")
-public interface FieldMapper {
-    Field addRequestBodyToField(AddFieldBodyRequest addFieldBodyRequest);
+public abstract class FieldMapper {
 
-    void updateFieldFromAddRequestBody(AddFieldBodyRequest addFieldBodyRequest,
+    private static final String UNIT = "unit";
+
+    private static final String UNIT_MAPPING_EXPRESSION = "java(saveUnitByNameIfNotExist.execute(addFieldBodyRequest.unitName()))";
+
+    @Autowired
+    protected SaveUnitByNameIfNotExist saveUnitByNameIfNotExist;
+
+    @Mapping(target = UNIT, expression = UNIT_MAPPING_EXPRESSION)
+    public abstract Field addRequestBodyToField(AddFieldBodyRequest addFieldBodyRequest);
+
+    @Mapping(target = UNIT, expression = UNIT_MAPPING_EXPRESSION)
+    public abstract void updateFieldFromAddRequestBody(AddFieldBodyRequest addFieldBodyRequest,
                                        @MappingTarget Field field);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/FieldMapper.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/FieldMapper.java
@@ -13,15 +13,18 @@ public abstract class FieldMapper {
 
     private static final String UNIT = "unit";
 
-    private static final String UNIT_MAPPING_EXPRESSION = "java(saveUnitByNameIfNotExist.execute(addFieldBodyRequest.unitName()))";
+    private static final String UNIT_MAPPING_EXPRESSION =
+            "java(saveUnitByNameIfNotExist.execute(addFieldBodyRequest.unitName()))";
 
     @Autowired
     protected SaveUnitByNameIfNotExist saveUnitByNameIfNotExist;
 
     @Mapping(target = UNIT, expression = UNIT_MAPPING_EXPRESSION)
-    public abstract Field addRequestBodyToField(AddFieldBodyRequest addFieldBodyRequest);
+    public abstract Field addRequestBodyToField(
+            AddFieldBodyRequest addFieldBodyRequest);
 
     @Mapping(target = UNIT, expression = UNIT_MAPPING_EXPRESSION)
-    public abstract void updateFieldFromAddRequestBody(AddFieldBodyRequest addFieldBodyRequest,
-                                       @MappingTarget Field field);
+    public abstract void updateFieldFromAddRequestBody(
+            AddFieldBodyRequest addFieldBodyRequest,
+            @MappingTarget Field field);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/FieldType.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/FieldType.java
@@ -1,0 +1,7 @@
+package pl.edu.agh.apdvbackend.models;
+
+public enum FieldType {
+    FOR_CHART,
+    STATIC_NUMBER,
+    STRING
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/Unit.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/Unit.java
@@ -2,30 +2,25 @@ package pl.edu.agh.apdvbackend.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "field")
+@Table(name = "unit")
 @Getter
 @Setter
 @NoArgsConstructor
-@JsonIgnoreProperties({"enableEndpointsForGroup"})
-public class Field {
+@JsonIgnoreProperties({"fields"})
+public class Unit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Schema(required = true)
@@ -33,17 +28,8 @@ public class Field {
 
     @Schema(required = true)
     @Column(unique = true)
-    private String label;
+    private String name;
 
-    @Enumerated(EnumType.ORDINAL)
-    private FieldType fieldType;
-
-    @Schema(required = true)
-    @ManyToOne
-    @JoinColumn(name = "unit_id")
-    private Unit unit;
-
-    @ManyToMany(mappedBy = "enableFields")
-    private List<EnableEndpointsForGroup> enableEndpointsForGroup =
-            new ArrayList<>();
+    @OneToMany(mappedBy = "unit")
+    private List<Field> fields;
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/repositories/UnitRepository.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/repositories/UnitRepository.java
@@ -1,0 +1,11 @@
+package pl.edu.agh.apdvbackend.repositories;
+
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+import pl.edu.agh.apdvbackend.models.Unit;
+
+public interface UnitRepository extends CrudRepository<Unit, Long> {
+    boolean existsByName(String name);
+
+    Optional<Unit> findByName(String name);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.AddEndpointRequestBody;
+import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointSummaryResponseBody;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.UserEndpointResponseBody;
 import pl.edu.agh.apdvbackend.models.Endpoint;
@@ -12,6 +13,7 @@ import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetAllEndpointSummaries;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetAllUserEndpoints;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetUserEndpointData;
+import pl.edu.agh.apdvbackend.use_cases.endpoint.GetUserEndpointDataWithFields;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.RemoveEndpointById;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.SaveNewEndpoint;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.UpdateEndpoint;
@@ -20,6 +22,8 @@ import pl.edu.agh.apdvbackend.use_cases.endpoint.UpdateEndpoint;
 @RequiredArgsConstructor
 public class EndpointService {
     private final GetUserEndpointData getUserEndpointData;
+
+    private final GetUserEndpointDataWithFields getUserEndpointDataWithFields;
 
     private final SaveNewEndpoint saveNewEndpoint;
 
@@ -37,13 +41,20 @@ public class EndpointService {
                 getUserEndpointData.execute(userId, sensorId));
     }
 
+    public Response<EndpointData> getDataWithFields(Long userId,
+                                                    Long sensorId) {
+        return Response.withOkStatus(
+                getUserEndpointDataWithFields.execute(userId, sensorId));
+    }
+
     public Response<List<EndpointSummaryResponseBody>> getEndpointsList() {
         return Response.withOkStatus(getAllEndpointSummaries.execute());
     }
 
-    public Endpoint addEndpoint(
+    public Response<Endpoint> addEndpoint(
             AddEndpointRequestBody addEndpointRequestBody) {
-        return saveNewEndpoint.execute(addEndpointRequestBody);
+        return Response.withOkStatus(
+                saveNewEndpoint.execute(addEndpointRequestBody));
     }
 
     public void removeEndpoint(Long endpointId) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/FieldService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/FieldService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import pl.edu.agh.apdvbackend.controllers.field.body_models.AddFieldBodyRequest;
 import pl.edu.agh.apdvbackend.models.Field;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
+import pl.edu.agh.apdvbackend.use_cases.field.GetAllEnableFieldsForEndpointAndUser;
 import pl.edu.agh.apdvbackend.use_cases.field.GetAllFields;
 import pl.edu.agh.apdvbackend.use_cases.field.RemoveField;
 import pl.edu.agh.apdvbackend.use_cases.field.SaveNewField;
@@ -19,6 +20,9 @@ public class FieldService {
 
     private final GetAllFields getAllFields;
 
+    private final GetAllEnableFieldsForEndpointAndUser
+            getAllEnableFieldsForEndpointAndUser;
+
     private final RemoveField removeField;
 
     private final UpdateField updateField;
@@ -29,6 +33,13 @@ public class FieldService {
 
     public Response<List<Field>> getAllFields() {
         return Response.withOkStatus(getAllFields.execute());
+    }
+
+    public Response<List<Field>> getAllEnableEndpoints(Long userId,
+                                                       Long endpointId) {
+        return Response.withOkStatus(
+                getAllEnableFieldsForEndpointAndUser.execute(userId,
+                        endpointId));
     }
 
     public void removeFieldById(Long fieldId) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFields.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFields.java
@@ -1,0 +1,7 @@
+package pl.edu.agh.apdvbackend.use_cases.endpoint;
+
+import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
+
+public interface GetUserEndpointDataWithFields {
+    EndpointData execute(Long userId, Long endpointId);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
@@ -1,0 +1,28 @@
+package pl.edu.agh.apdvbackend.use_cases.endpoint;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
+import pl.edu.agh.apdvbackend.use_cases.enable_endpoints.GetEnableEndpointByUserAndEndpointId;
+
+@Component
+@RequiredArgsConstructor
+public class GetUserEndpointDataWithFieldsImpl
+        implements GetUserEndpointDataWithFields {
+
+    private final GetUserEndpointData getUserEndpointData;
+
+    private final GetEnableEndpointByUserAndEndpointId
+            getEnableEndpointByUserAndEndpointId;
+
+    @Override
+    public EndpointData execute(Long userId, Long endpointId) {
+        final var fields = getEnableEndpointByUserAndEndpointId
+                .execute(userId, endpointId)
+                .getEnableFields();
+        final var endpointData =
+                getUserEndpointData.execute(userId, endpointId);
+
+        return new EndpointData(fields, endpointData);
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
@@ -3,7 +3,7 @@ package pl.edu.agh.apdvbackend.use_cases.endpoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
-import pl.edu.agh.apdvbackend.use_cases.enable_endpoints.GetEnableEndpointByUserAndEndpointId;
+import pl.edu.agh.apdvbackend.use_cases.field.GetAllEnableFieldsForEndpointAndUser;
 
 @Component
 @RequiredArgsConstructor
@@ -12,14 +12,12 @@ public class GetUserEndpointDataWithFieldsImpl
 
     private final GetUserEndpointData getUserEndpointData;
 
-    private final GetEnableEndpointByUserAndEndpointId
-            getEnableEndpointByUserAndEndpointId;
+    private final GetAllEnableFieldsForEndpointAndUser getEnableFields;
 
     @Override
     public EndpointData execute(Long userId, Long endpointId) {
-        final var fields = getEnableEndpointByUserAndEndpointId
-                .execute(userId, endpointId)
-                .getEnableFields();
+        final var fields = getEnableFields
+                .execute(userId, endpointId);
         final var endpointData =
                 getUserEndpointData.execute(userId, endpointId);
 

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
@@ -3,6 +3,7 @@ package pl.edu.agh.apdvbackend.use_cases.endpoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
+import pl.edu.agh.apdvbackend.mappers.FieldMapper;
 import pl.edu.agh.apdvbackend.use_cases.field.GetAllEnableFieldsForEndpointAndUser;
 
 @Component
@@ -14,13 +15,17 @@ public class GetUserEndpointDataWithFieldsImpl
 
     private final GetAllEnableFieldsForEndpointAndUser getEnableFields;
 
+    private final FieldMapper fieldMapper;
+
     @Override
     public EndpointData execute(Long userId, Long endpointId) {
         final var fields = getEnableFields
                 .execute(userId, endpointId);
+        final var fieldsWithoutId =
+                fieldMapper.fieldListToWithoutIdList(fields);
         final var endpointData =
                 getUserEndpointData.execute(userId, endpointId);
 
-        return new EndpointData(fields, endpointData);
+        return new EndpointData(fieldsWithoutId, endpointData);
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsForEndpointAndUser.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsForEndpointAndUser.java
@@ -1,0 +1,8 @@
+package pl.edu.agh.apdvbackend.use_cases.field;
+
+import java.util.List;
+import pl.edu.agh.apdvbackend.models.Field;
+
+public interface GetAllEnableFieldsForEndpointAndUser {
+    List<Field> execute(Long userId, Long endpointId);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsForEndpointAndUserImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsForEndpointAndUserImpl.java
@@ -1,0 +1,23 @@
+package pl.edu.agh.apdvbackend.use_cases.field;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.models.Field;
+import pl.edu.agh.apdvbackend.use_cases.enable_endpoints.GetEnableEndpointByUserAndEndpointId;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllEnableFieldsForEndpointAndUserImpl
+        implements GetAllEnableFieldsForEndpointAndUser {
+
+    private final GetEnableEndpointByUserAndEndpointId
+            getEnableEndpointByUserAndEndpointId;
+
+    @Override
+    public List<Field> execute(Long userId, Long endpointId) {
+        return getEnableEndpointByUserAndEndpointId
+                .execute(userId, endpointId)
+                .getEnableFields();
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/unit/SaveUnitByNameIfNotExist.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/unit/SaveUnitByNameIfNotExist.java
@@ -1,0 +1,7 @@
+package pl.edu.agh.apdvbackend.use_cases.unit;
+
+import pl.edu.agh.apdvbackend.models.Unit;
+
+public interface SaveUnitByNameIfNotExist {
+    Unit execute(String unitName);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/unit/SaveUnitByNameIfNotExistImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/unit/SaveUnitByNameIfNotExistImpl.java
@@ -1,0 +1,27 @@
+package pl.edu.agh.apdvbackend.use_cases.unit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.models.Unit;
+import pl.edu.agh.apdvbackend.repositories.UnitRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SaveUnitByNameIfNotExistImpl
+        implements SaveUnitByNameIfNotExist {
+
+    private final UnitRepository unitRepository;
+
+    @Override
+    public Unit execute(String unitName) {
+        return unitRepository
+                .findByName(unitName)
+                .orElseGet(() -> makeAndSaveNewUnit(unitName));
+    }
+
+    private Unit makeAndSaveNewUnit(String unitName) {
+        final var unit = new Unit();
+        unit.setName(unitName);
+        return unitRepository.save(unit);
+    }
+}


### PR DESCRIPTION
- Dodałem nowe API:
   - GET `/field/enable` - zwraca dostępne pola, dla określonego użytkownika (na ten moment zhardkorowane) i endpoita,
   - GET `/sensor/data` - to co wyżej + dane z endpointa jak dla GET `/sensor`,
- Dodałem jednostki i typy pól (do rysowania wykresów oznaczone jako `FOR_CHART`),
- Zrobiłem lekki update `mock.sql`, więc zalecam na nowo postawić sobie bazę,
- Tabela z przelicznikami jednostek będzie zaimplementowana w osobnym tasku.