### PR TITLE
[APDV-70] Back Stworzyć API do pobierania ostatnich pomiarów

### DIFF
--- a/backend/sql_mocks/mock.sql
+++ b/backend/sql_mocks/mock.sql
@@ -1,8 +1,8 @@
 INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (96, 'AGH Test sensor', '/pl/datasets/dyplomy-2022/endpoints/96/data/');
 INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (101, 'AGH Sensor 101', '/pl/datasets/env-mon-agh/endpoints/101/data/');
 INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (59, 'AGH Sensor 59', '/pl/datasets/env-mon-agh/endpoints/59/data/');
-INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (75, 'Ochotnica Konopnickiej', '/pl/datasets/stacje-ochotnica-21/endpoints/75/data/?limit=25');
-INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (74, 'Ochotnica Twardowskiego', '/pl/datasets/stacje-ochotnica-21/endpoints/74/data/?limit=25');
+INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (75, 'Ochotnica Konopnickiej', '/pl/datasets/stacje-ochotnica-21/endpoints/75/data/');
+INSERT INTO public.endpoint (endpoint_number, label, sensor_url) VALUES (74, 'Ochotnica Twardowskiego', '/pl/datasets/stacje-ochotnica-21/endpoints/74/data/');
 
 INSERT INTO public.unit (name) VALUES ('°C');
 INSERT INTO public.unit (name) VALUES ('Pa');

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
@@ -34,15 +34,19 @@ public class EndpointController {
     @Operation(summary = "Get list of data from sensor that belongs to user")
     @GetMapping
     public Response<List<ObjectNode>> getData(
-            @RequestParam Long sensorId) {
-        return endpointService.getData(USER_ID, sensorId);
+            @RequestParam Long sensorId,
+            @RequestParam(required = false, defaultValue = "25") int limit,
+            @RequestParam(required = false, defaultValue = "0") int offset) {
+        return endpointService.getData(USER_ID, sensorId, limit, offset);
     }
 
     @Operation(summary = "Get list of data from sensor that belongs to user with enable fields")
     @GetMapping("/data")
     public Response<EndpointData> getDataWithFields(
-            @RequestParam Long sensorId) {
-        return endpointService.getDataWithFields(USER_ID, sensorId);
+            @RequestParam Long sensorId,
+            @RequestParam(required = false, defaultValue = "25") int limit,
+            @RequestParam(required = false, defaultValue = "0") int offset) {
+        return endpointService.getDataWithFields(USER_ID, sensorId, limit, offset);
     }
 
     @Operation(summary = "Get user's endpoints list")

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/endpoint/EndpointController.java
@@ -35,8 +35,8 @@ public class EndpointController {
     @GetMapping
     public Response<List<ObjectNode>> getData(
             @RequestParam Long sensorId,
-            @RequestParam(required = false, defaultValue = "25") int limit,
-            @RequestParam(required = false, defaultValue = "0") int offset) {
+            @RequestParam(required = false, defaultValue = "25") Long limit,
+            @RequestParam(required = false, defaultValue = "0") Long offset) {
         return endpointService.getData(USER_ID, sensorId, limit, offset);
     }
 
@@ -44,9 +44,10 @@ public class EndpointController {
     @GetMapping("/data")
     public Response<EndpointData> getDataWithFields(
             @RequestParam Long sensorId,
-            @RequestParam(required = false, defaultValue = "25") int limit,
-            @RequestParam(required = false, defaultValue = "0") int offset) {
-        return endpointService.getDataWithFields(USER_ID, sensorId, limit, offset);
+            @RequestParam(required = false, defaultValue = "25") Long limit,
+            @RequestParam(required = false, defaultValue = "0") Long offset) {
+        return endpointService.getDataWithFields(USER_ID, sensorId, limit,
+                offset);
     }
 
     @Operation(summary = "Get user's endpoints list")

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
@@ -37,18 +37,19 @@ public class EndpointService {
 
     public Response<List<ObjectNode>> getData(Long userId,
                                               Long sensorId,
-                                              int limit,
-                                              int offset) {
+                                              Long limit,
+                                              Long offset) {
         return Response.withOkStatus(
                 getUserEndpointData.execute(userId, sensorId, limit, offset));
     }
 
     public Response<EndpointData> getDataWithFields(Long userId,
                                                     Long sensorId,
-                                                    int limit,
-                                                    int offset) {
+                                                    Long limit,
+                                                    Long offset) {
         return Response.withOkStatus(
-                getUserEndpointDataWithFields.execute(userId, sensorId, limit, offset));
+                getUserEndpointDataWithFields.execute(userId, sensorId, limit,
+                        offset));
     }
 
     public Response<List<EndpointSummaryResponseBody>> getEndpointsList() {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
@@ -36,15 +36,19 @@ public class EndpointService {
     private final UpdateEndpoint updateEndpoint;
 
     public Response<List<ObjectNode>> getData(Long userId,
-                                              Long sensorId) {
+                                              Long sensorId,
+                                              int limit,
+                                              int offset) {
         return Response.withOkStatus(
-                getUserEndpointData.execute(userId, sensorId));
+                getUserEndpointData.execute(userId, sensorId, limit, offset));
     }
 
     public Response<EndpointData> getDataWithFields(Long userId,
-                                                    Long sensorId) {
+                                                    Long sensorId,
+                                                    int limit,
+                                                    int offset) {
         return Response.withOkStatus(
-                getUserEndpointDataWithFields.execute(userId, sensorId));
+                getUserEndpointDataWithFields.execute(userId, sensorId, limit, offset));
     }
 
     public Response<List<EndpointSummaryResponseBody>> getEndpointsList() {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHub.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHub.java
@@ -4,7 +4,5 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Iterator;
 
 public interface GetJsonNodeFromDataHub {
-    Iterator<JsonNode> execute(String uri);
-
-    Iterator<JsonNode> execute(String uri, int limit, int offset);
+    Iterator<JsonNode> execute(String uri, Long limit, Long offset);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHub.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHub.java
@@ -5,4 +5,6 @@ import java.util.Iterator;
 
 public interface GetJsonNodeFromDataHub {
     Iterator<JsonNode> execute(String uri);
+
+    Iterator<JsonNode> execute(String uri, int limit, int offset);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHubImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHubImpl.java
@@ -12,21 +12,39 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class GetJsonNodeFromDataHubImpl
         implements GetJsonNodeFromDataHub {
 
+    private static final String LIMIT = "limit";
+
+    private static final String OFFSET = "offset";
+
     private static final String RESULTS = "results";
+
+    private static final int STANDARD_LIMIT = 25;
+
+    private static final int STANDARD_OFFSET = 0;
 
     private final WebClient webClient;
 
     @Override
     public Iterator<JsonNode> execute(String uri) {
-        return makeRequest(uri)
+        return execute(uri, STANDARD_LIMIT, STANDARD_OFFSET);
+    }
+
+    @Override
+    public Iterator<JsonNode> execute(String uri, int limit, int offset) {
+        return makeRequest(uri, limit, offset)
                 .get(RESULTS)
                 .iterator();
     }
 
-    private ObjectNode makeRequest(String uri) {
+
+    private ObjectNode makeRequest(String uri, int limit, int offset) {
         return webClient
                 .get()
-                .uri(uri)
+                .uri(uriBuilder -> uriBuilder
+                        .path(uri)
+                        .queryParam(LIMIT, limit)
+                        .queryParam(OFFSET, offset)
+                        .build())
                 .retrieve()
                 .bodyToMono(ObjectNode.class)
                 .block();

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHubImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/datahub/GetJsonNodeFromDataHubImpl.java
@@ -18,26 +18,17 @@ public class GetJsonNodeFromDataHubImpl
 
     private static final String RESULTS = "results";
 
-    private static final int STANDARD_LIMIT = 25;
-
-    private static final int STANDARD_OFFSET = 0;
-
     private final WebClient webClient;
 
     @Override
-    public Iterator<JsonNode> execute(String uri) {
-        return execute(uri, STANDARD_LIMIT, STANDARD_OFFSET);
-    }
-
-    @Override
-    public Iterator<JsonNode> execute(String uri, int limit, int offset) {
+    public Iterator<JsonNode> execute(String uri, Long limit, Long offset) {
         return makeRequest(uri, limit, offset)
                 .get(RESULTS)
                 .iterator();
     }
 
 
-    private ObjectNode makeRequest(String uri, int limit, int offset) {
+    private ObjectNode makeRequest(String uri, Long limit, Long offset) {
         return webClient
                 .get()
                 .uri(uriBuilder -> uriBuilder

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointData.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointData.java
@@ -4,5 +4,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 
 public interface GetUserEndpointData {
-    List<ObjectNode> execute(Long userId, Long endpointId, int limit, int offset);
+    List<ObjectNode> execute(Long userId, Long endpointId, Long limit,
+                             Long offset);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointData.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointData.java
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 
 public interface GetUserEndpointData {
-    List<ObjectNode> execute(Long userId, Long endpointId);
+    List<ObjectNode> execute(Long userId, Long endpointId, int limit, int offset);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataImpl.java
@@ -28,13 +28,15 @@ public class GetUserEndpointDataImpl
     private final GetJsonNodeFromDataHub getJsonNodeFromDataHub;
 
     @Override
-    public List<ObjectNode> execute(Long userId, Long endpointId, int limit, int offset) {
+    public List<ObjectNode> execute(Long userId, Long endpointId, Long limit,
+                                    Long offset) {
         final var enableEndpoint =
                 getEnableEndpointByUserAndEndpointId.execute(userId,
                         endpointId);
         final var endpoint = enableEndpoint.getEndpoint();
         final var rawEndpointData =
-                getJsonNodeFromDataHub.execute(endpoint.getSensorUrl(), limit, offset);
+                getJsonNodeFromDataHub.execute(endpoint.getSensorUrl(), limit,
+                        offset);
 
         return parseWeatherData(rawEndpointData, endpoint,
                 enableEndpoint.getEnableFields());

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataImpl.java
@@ -28,13 +28,13 @@ public class GetUserEndpointDataImpl
     private final GetJsonNodeFromDataHub getJsonNodeFromDataHub;
 
     @Override
-    public List<ObjectNode> execute(Long userId, Long endpointId) {
+    public List<ObjectNode> execute(Long userId, Long endpointId, int limit, int offset) {
         final var enableEndpoint =
                 getEnableEndpointByUserAndEndpointId.execute(userId,
                         endpointId);
         final var endpoint = enableEndpoint.getEndpoint();
         final var rawEndpointData =
-                getJsonNodeFromDataHub.execute(endpoint.getSensorUrl());
+                getJsonNodeFromDataHub.execute(endpoint.getSensorUrl(), limit, offset);
 
         return parseWeatherData(rawEndpointData, endpoint,
                 enableEndpoint.getEnableFields());

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFields.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFields.java
@@ -3,5 +3,5 @@ package pl.edu.agh.apdvbackend.use_cases.endpoint;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
 
 public interface GetUserEndpointDataWithFields {
-    EndpointData execute(Long userId, Long endpointId, int limit, int offset);
+    EndpointData execute(Long userId, Long endpointId, Long limit, Long offset);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFields.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFields.java
@@ -3,5 +3,5 @@ package pl.edu.agh.apdvbackend.use_cases.endpoint;
 import pl.edu.agh.apdvbackend.controllers.endpoint.body_models.EndpointData;
 
 public interface GetUserEndpointDataWithFields {
-    EndpointData execute(Long userId, Long endpointId);
+    EndpointData execute(Long userId, Long endpointId, int limit, int offset);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
@@ -18,13 +18,13 @@ public class GetUserEndpointDataWithFieldsImpl
     private final FieldMapper fieldMapper;
 
     @Override
-    public EndpointData execute(Long userId, Long endpointId) {
+    public EndpointData execute(Long userId, Long endpointId, int limit, int offset) {
         final var fields = getEnableFields
                 .execute(userId, endpointId);
         final var fieldsWithoutId =
                 fieldMapper.fieldListToWithoutIdList(fields);
         final var endpointData =
-                getUserEndpointData.execute(userId, endpointId);
+                getUserEndpointData.execute(userId, endpointId, limit, offset);
 
         return new EndpointData(fieldsWithoutId, endpointData);
     }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetUserEndpointDataWithFieldsImpl.java
@@ -18,7 +18,8 @@ public class GetUserEndpointDataWithFieldsImpl
     private final FieldMapper fieldMapper;
 
     @Override
-    public EndpointData execute(Long userId, Long endpointId, int limit, int offset) {
+    public EndpointData execute(Long userId, Long endpointId, Long limit,
+                                Long offset) {
         final var fields = getEnableFields
                 .execute(userId, endpointId);
         final var fieldsWithoutId =


### PR DESCRIPTION
- Zmieniłem lekko API do pobierania pomiarów z czujnika. Teraz można wybrać `limit` i `offset`, tak jak to jest zrobione na Datahubie,
- Zmiany te nie powodują, że API nie jest wstecznie kompatybilne z poprzednią wersją.