### PR TITLE
APDV-91 zabezpieczenie endpointow

### DIFF
--- a/backend/sql_mocks/mock.sql
+++ b/backend/sql_mocks/mock.sql
@@ -107,9 +107,18 @@ INSERT INTO public.fields_parser_mapping (endpoint_id, field_parser_id, field_id
 
 INSERT INTO public.group (name) VALUES ('Best officials');
 
-INSERT INTO public.user (email, name) VALUES ('test@test.com', 'Jan');
+-- Roles: USER,ADMIN; Password: 1234
+INSERT INTO public.user (email, name, password) VALUES ('admin@test.com', 'Jan', '$2a$10$bb7HuTrdYSg/wVAOVVU.YeG5Wx4JFdKLccz3tWPoVsWWWEqtPoPJK');
+
+-- Roles: USER; Password: 1234
+INSERT INTO public.user (email, name, password) VALUES ('user@test.com', 'Karol', '$2a$10$bb7HuTrdYSg/wVAOVVU.YeG5Wx4JFdKLccz3tWPoVsWWWEqtPoPJK');
 
 INSERT INTO public.users_in_group (group_id, user_id) VALUES (1, 1);
+INSERT INTO public.users_in_group (group_id, user_id) VALUES (1, 2);
+
+INSERT INTO public.user_role(user_id, role_id) VALUES (1, 0);
+INSERT INTO public.user_role(user_id, role_id) VALUES (1, 1);
+INSERT INTO public.user_role(user_id, role_id) VALUES (2, 0);
 
 INSERT INTO public.enable_endpoints_for_group (endpoint_id, group_id, approximation_precission, detailed_measurement_days) VALUES (1, 1, 10, 10);
 INSERT INTO public.enable_endpoints_for_group (endpoint_id, group_id, approximation_precission, detailed_measurement_days) VALUES (2, 1, 10, 10);

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/auth/CustomAuthorizationFilter.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/auth/CustomAuthorizationFilter.java
@@ -1,0 +1,92 @@
+package pl.edu.agh.apdvbackend.auth;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String TOKEN_PREFIX = "Bearer ";
+
+    private static final String ROLES = "roles";
+
+    private static final String ERROR = "error";
+
+    private final Algorithm algorithm;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+        final var authorizationHeader = request.getHeader(AUTHORIZATION);
+        if (!isAuthorizationHeaderFormatProper(authorizationHeader)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            tryToUpdateSecurityContext(request, response, filterChain,
+                    authorizationHeader);
+        } catch (Exception exception) {
+            sendErrorResponse(response, exception);
+        }
+    }
+
+    private boolean isAuthorizationHeaderFormatProper(
+            String authorizationHeader) {
+        return authorizationHeader != null &&
+                authorizationHeader.startsWith(TOKEN_PREFIX);
+    }
+
+    private void tryToUpdateSecurityContext(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain filterChain,
+                                            String authorizationHeader)
+            throws IOException, ServletException {
+        final var token =
+                authorizationHeader.substring(TOKEN_PREFIX.length());
+        final JWTVerifier verifier = JWT.require(algorithm).build();
+        final var decodedJWT = verifier.verify(token);
+        final var username = decodedJWT.getSubject();
+        final var roles = getRoles(decodedJWT);
+        final var authenticationToken =
+                new UsernamePasswordAuthenticationToken(username, null, roles);
+        SecurityContextHolder.getContext()
+                .setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+
+    private List<SimpleGrantedAuthority> getRoles(DecodedJWT decodedJWT) {
+        return Arrays.stream(decodedJWT
+                        .getClaim(ROLES)
+                        .asArray(String.class))
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+
+    private void sendErrorResponse(HttpServletResponse response,
+                                   Exception exception)
+            throws IOException {
+        response.setHeader(ERROR, exception.getMessage());
+        response.sendError(FORBIDDEN.value());
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
@@ -11,12 +11,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import pl.edu.agh.apdvbackend.models.database.Role;
-import org.springframework.security.core.Authentication;
 
 @Configuration
 @EnableWebSecurity

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -40,14 +39,19 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.csrf().disable();
         http.sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        http.authorizeRequests().antMatchers(HttpMethod.POST, "/auth/**").permitAll();
-        http.authorizeRequests().antMatchers("/v3/api-docs/**",
-                "/configuration/ui",
-                "/swagger-resources/**",
-                "/configuration/security",
+        http.authorizeRequests().antMatchers(
+                "/v3/api-docs/**",
                 "/swagger-ui/**",
-                "/webjars/**").permitAll();
-        http.authorizeRequests().anyRequest().authenticated();
+                "/auth/**"
+        ).permitAll();
+        http.authorizeRequests().antMatchers(HttpMethod.GET,
+                "/sensor/data",
+                "/sensor",
+                "/sensor/list",
+                "/field/enable",
+                "/unit/converter",
+                "/unit/converter/all").hasAuthority(Role.USER.name());
+        http.authorizeRequests().anyRequest().hasAuthority(Role.ADMIN.name());
         http.addFilterBefore(new CustomAuthorizationFilter(getAlgorithm()),
                 UsernamePasswordAuthenticationFilter.class);
     }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
@@ -11,10 +11,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import pl.edu.agh.apdvbackend.models.database.Role;
+import org.springframework.security.core.Authentication;
 
 @Configuration
 @EnableWebSecurity

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/auth/SecurityConfig.java
@@ -4,14 +4,18 @@ import com.auth0.jwt.algorithms.Algorithm;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import pl.edu.agh.apdvbackend.models.database.Role;
 
 @Configuration
 @EnableWebSecurity
@@ -36,7 +40,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.csrf().disable();
         http.sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        http.authorizeRequests().anyRequest().permitAll();
+        http.authorizeRequests().antMatchers(HttpMethod.POST, "/auth/**").permitAll();
+        http.authorizeRequests().antMatchers("/v3/api-docs/**",
+                "/configuration/ui",
+                "/swagger-resources/**",
+                "/configuration/security",
+                "/swagger-ui/**",
+                "/webjars/**").permitAll();
+        http.authorizeRequests().anyRequest().authenticated();
+        http.addFilterBefore(new CustomAuthorizationFilter(getAlgorithm()),
+                UsernamePasswordAuthenticationFilter.class);
     }
 
     @Bean

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/configs/SwaggerConfig.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/configs/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package pl.edu.agh.apdvbackend.configs;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    public static final String JWT_AUTH = "JWT_AUTH";
+
+    @Bean
+    public OpenAPI configureApi() {
+        return new OpenAPI().components(
+                new Components()
+                        .addSecuritySchemes(JWT_AUTH, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT"))
+        );
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/AuthController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/AuthController.java
@@ -1,5 +1,6 @@
 package pl.edu.agh.apdvbackend.controllers;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,12 +21,14 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @Operation(summary = "Log in user to backend")
     @PostMapping("/login")
     public Response<JWTResponse> logInUser(
             @RequestBody LogInRequestBody logInRequestBody) {
         return authService.logInUser(logInRequestBody);
     }
 
+    @Operation(summary = "Register new user")
     @PostMapping("/register")
     public Response<JWTResponse> registerUser(
             @RequestBody AddUserRequestBody addUserRequestBody) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
@@ -33,7 +33,7 @@ public class EndpointController {
 
     private final EndpointService endpointService;
 
-    @Operation(summary = "Get list of data from sensor that belongs to user")
+    @Operation(summary = "Get list of data from sensor that belongs to user", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping
     public Response<List<ObjectNode>> getData(
             @RequestParam Long sensorId,
@@ -42,7 +42,7 @@ public class EndpointController {
         return endpointService.getData(USER_ID, sensorId, limit, offset);
     }
 
-    @Operation(summary = "Get list of data from sensor that belongs to user with enable fields")
+    @Operation(summary = "Get list of data from sensor that belongs to user with enable fields", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/data")
     public Response<EndpointData> getDataWithFields(
             @RequestParam Long sensorId,
@@ -52,32 +52,32 @@ public class EndpointController {
                 offset);
     }
 
-    @Operation(summary = "Get user's endpoints list")
+    @Operation(summary = "Get user's endpoints list", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/list")
     public Response<List<UserEndpointResponseBody>> getUserEndpointsList() {
         return endpointService.getUserEndpointsList(USER_ID);
     }
 
-    @Operation(summary = "Get all endpoints list with fields information")
+    @Operation(summary = "Get all endpoints list with fields information", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/list/all")
     public Response<List<EndpointSummaryResponseBody>> getEndpointsList() {
         return endpointService.getEndpointsList();
     }
 
-    @Operation(summary = "Add new endpoint")
+    @Operation(summary = "Add new endpoint", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping
     public Response<Endpoint> addEndpoint(
             @RequestBody AddEndpointRequestBody addEndpointRequestBody) {
         return endpointService.addEndpoint(addEndpointRequestBody);
     }
 
-    @Operation(summary = "Remove endpoint")
+    @Operation(summary = "Remove endpoint", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping
     public void removeEndpoint(@RequestParam Long endpointId) {
         endpointService.removeEndpoint(endpointId);
     }
 
-    @Operation(summary = "Update endpoint")
+    @Operation(summary = "Update endpoint", security = @SecurityRequirement(name = JWT_AUTH))
     @PutMapping
     public Response<Endpoint> updateEndpoint(
             @RequestBody AddEndpointRequestBody addEndpointRequestBody,

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
@@ -2,6 +2,7 @@ package pl.edu.agh.apdvbackend.controllers;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.endpoint.AddEndpointRequestBody;
 import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointData;

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
@@ -28,9 +28,6 @@ import pl.edu.agh.apdvbackend.services.EndpointService;
 @RequiredArgsConstructor
 @Tag(name = "Endpoint")
 public class EndpointController {
-    // TODO: Remove USER_ID when JWT will be implemented
-    private static final Long USER_ID = 1L;
-
     private final EndpointService endpointService;
 
     @Operation(summary = "Get list of data from sensor that belongs to user", security = @SecurityRequirement(name = JWT_AUTH))
@@ -39,7 +36,7 @@ public class EndpointController {
             @RequestParam Long sensorId,
             @RequestParam(required = false, defaultValue = "25") Long limit,
             @RequestParam(required = false, defaultValue = "0") Long offset) {
-        return endpointService.getData(USER_ID, sensorId, limit, offset);
+        return endpointService.getData(sensorId, limit, offset);
     }
 
     @Operation(summary = "Get list of data from sensor that belongs to user with enable fields", security = @SecurityRequirement(name = JWT_AUTH))
@@ -48,14 +45,13 @@ public class EndpointController {
             @RequestParam Long sensorId,
             @RequestParam(required = false, defaultValue = "25") Long limit,
             @RequestParam(required = false, defaultValue = "0") Long offset) {
-        return endpointService.getDataWithFields(USER_ID, sensorId, limit,
-                offset);
+        return endpointService.getDataWithFields(sensorId, limit, offset);
     }
 
     @Operation(summary = "Get user's endpoints list", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/list")
     public Response<List<UserEndpointResponseBody>> getUserEndpointsList() {
-        return endpointService.getUserEndpointsList(USER_ID);
+        return endpointService.getUserEndpointsList();
     }
 
     @Operation(summary = "Get all endpoints list with fields information", security = @SecurityRequirement(name = JWT_AUTH))

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.apdvbackend.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.field.AddFieldBodyRequest;
 import pl.edu.agh.apdvbackend.models.database.Field;
@@ -27,33 +29,33 @@ public class FieldController {
 
     private final FieldService fieldService;
 
-    @Operation(summary = "Add new field")
+    @Operation(summary = "Add new field", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping
     public Response<Field> addField(
             @RequestBody AddFieldBodyRequest addFieldBodyRequest) {
         return fieldService.addField(addFieldBodyRequest);
     }
 
-    @Operation(summary = "Get list of all fields")
+    @Operation(summary = "Get list of all fields", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping
     public Response<List<Field>> getAllFields() {
         return fieldService.getAllFields();
     }
 
-    @Operation(summary = "Get list of fields, that are enable for user by endpointId")
+    @Operation(summary = "Get list of fields, that are enable for user by endpointId", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/enable")
     public Response<List<Field>> getAllEnableEndpoints(
             @RequestParam Long endpointId) {
         return fieldService.getAllEnableEndpoints(USER_ID, endpointId);
     }
 
-    @Operation(summary = "Remove field by id")
+    @Operation(summary = "Remove field by id", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping
     public void removeFieldById(@RequestParam Long fieldId) {
         fieldService.removeFieldById(fieldId);
     }
 
-    @Operation(summary = "Update field")
+    @Operation(summary = "Update field", security = @SecurityRequirement(name = JWT_AUTH))
     @PutMapping
     public Response<Field> updateField(
             @RequestParam Long fieldId,

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
@@ -24,8 +24,6 @@ import pl.edu.agh.apdvbackend.services.FieldService;
 @RequiredArgsConstructor
 @Tag(name = "Field")
 public class FieldController {
-    // TODO: Remove USER_ID when JWT will be implemented
-    private static final Long USER_ID = 1L;
 
     private final FieldService fieldService;
 
@@ -46,7 +44,7 @@ public class FieldController {
     @GetMapping("/enable")
     public Response<List<Field>> getAllEnableEndpoints(
             @RequestParam Long endpointId) {
-        return fieldService.getAllEnableEndpoints(USER_ID, endpointId);
+        return fieldService.getAllEnableEndpoints(endpointId);
     }
 
     @Operation(summary = "Remove field by id", security = @SecurityRequirement(name = JWT_AUTH))

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldParserController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldParserController.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.apdvbackend.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.field_parser.AddFieldParserRequestBody;
 import pl.edu.agh.apdvbackend.models.database.FieldParser;
@@ -25,26 +27,26 @@ public class FieldParserController {
 
     private final FieldParserService fieldParserService;
 
-    @Operation(summary = "Add new field parser")
+    @Operation(summary = "Add new field parser", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping
     public Response<FieldParser> addField(
             @RequestBody AddFieldParserRequestBody addFieldParserRequestBody) {
         return fieldParserService.addFieldParser(addFieldParserRequestBody);
     }
 
-    @Operation(summary = "Get list of all field parsers")
+    @Operation(summary = "Get list of all field parsers", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping
     public Response<List<FieldParser>> getAllFields() {
         return fieldParserService.getAllFieldParsers();
     }
 
-    @Operation(summary = "Remove field parser by id")
+    @Operation(summary = "Remove field parser by id", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping
     public void removeFieldById(@RequestParam Long fieldParserId) {
         fieldParserService.removeFieldParserById(fieldParserId);
     }
 
-    @Operation(summary = "Update field parser")
+    @Operation(summary = "Update field parser", security = @SecurityRequirement(name = JWT_AUTH))
     @PutMapping
     public Response<FieldParser> updateFieldParser(
             @RequestParam Long fieldParserId,

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/GroupController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/GroupController.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.apdvbackend.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.group.AboutGroupResponseBody;
 import pl.edu.agh.apdvbackend.models.body_models.group.AddEnableEndpointRequestBody;
@@ -27,40 +29,40 @@ public class GroupController {
 
     private final GroupService groupService;
 
-    @Operation(summary = "Get id and name info about all group")
+    @Operation(summary = "Get id and name info about all group", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/all/info")
     public Response<List<ShortGroupInfoResponseBody>> getAllGroupsInfo() {
         return groupService.getAllGroupsInfo();
     }
 
-    @Operation(summary = "Get information about group")
+    @Operation(summary = "Get information about group", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping
     public Response<AboutGroupResponseBody> getGroupInfo(
             @RequestParam Long groupId) {
         return groupService.getGroupInfo(groupId);
     }
 
-    @Operation(summary = "Add user to group")
+    @Operation(summary = "Add user to group", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping("/user/add")
     public Response<AboutGroupResponseBody> addUserToGroup(
             @RequestParam Long groupId, @RequestParam Long userId) {
         return groupService.addUserToGroup(groupId, userId);
     }
 
-    @Operation(summary = "Remove user from group")
+    @Operation(summary = "Remove user from group", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping("/user/remove")
     public Response<AboutGroupResponseBody> removeUserFromGroup(
             @RequestParam Long groupId, @RequestParam Long userId) {
         return groupService.removeUserFromGroup(groupId, userId);
     }
 
-    @Operation(summary = "Remove group")
+    @Operation(summary = "Remove group", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping
     public void removeGroup(@RequestParam Long groupId) {
         groupService.removeGroup(groupId);
     }
 
-    @Operation(summary = "Change enable endpoints for group")
+    @Operation(summary = "Change enable endpoints for group", security = @SecurityRequirement(name = JWT_AUTH))
     @PutMapping("/endpoints")
     public Response<AboutGroupResponseBody> changeEnableEndpoints(@RequestBody
                                                                   List<AddEnableEndpointRequestBody> addEnableEndpointRequestBodyList,
@@ -70,7 +72,7 @@ public class GroupController {
                 addEnableEndpointRequestBodyList, groupId);
     }
 
-    @Operation(summary = "Add new group")
+    @Operation(summary = "Add new group", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping
     public Response<AboutGroupResponseBody> addGroup(
             @RequestBody AddGroupRequestBody addGroupRequestBody) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/UnitConverterController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/UnitConverterController.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.apdvbackend.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.unit_converter.AddUnitConverterRequestBody;
 import pl.edu.agh.apdvbackend.models.body_models.unit_converter.UnitConverterResponseBody;
@@ -25,20 +27,20 @@ public class UnitConverterController {
 
     private final UnitConverterService unitConverterService;
 
-    @Operation(summary = "Get all available unit converters.")
+    @Operation(summary = "Get all available unit converters.", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/all")
     public Response<List<UnitConverterResponseBody>> getAllUnitConverters() {
         return unitConverterService.getAllUnitConverters();
     }
 
-    @Operation(summary = "Get all unit converters related with specific unit.")
+    @Operation(summary = "Get all unit converters related with specific unit.", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping
     public Response<List<UnitConverterResponseBody>> getAllUnitConvertersRelatedWithUnit(
             @RequestParam Long unitId) {
         return unitConverterService.getAllUnitConvertersRelatedWithUnit(unitId);
     }
 
-    @Operation(summary = "Add new unit converter")
+    @Operation(summary = "Add new unit converter", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping
     public Response<UnitConverterResponseBody> addUnitConverter(@RequestBody
                                                                 AddUnitConverterRequestBody addUnitConverterRequestBody) {
@@ -46,13 +48,13 @@ public class UnitConverterController {
                 addUnitConverterRequestBody);
     }
 
-    @Operation(summary = "Delete unit converter")
+    @Operation(summary = "Delete unit converter", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping
     public void removeUnitConverter(@RequestParam Long unitConverterId) {
         unitConverterService.removeUnitConverter(unitConverterId);
     }
 
-    @Operation(summary = "Update unit converter")
+    @Operation(summary = "Update unit converter", security = @SecurityRequirement(name = JWT_AUTH))
     @PutMapping
     public Response<UnitConverterResponseBody> updateUnitConverter(
             @RequestParam Long unitConverterId, @RequestBody

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/UserController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/UserController.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.apdvbackend.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.user.AboutUserResponseBody;
 import pl.edu.agh.apdvbackend.models.body_models.user.AddUserRequestBody;
@@ -26,33 +28,33 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "Get all users information")
+    @Operation(summary = "Get all users information", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping("/all")
     public Response<List<AboutUserResponseBody>> getAllUsers() {
         return userService.getAllUsers();
     }
 
-    @Operation(summary = "Get user information")
+    @Operation(summary = "Get user information", security = @SecurityRequirement(name = JWT_AUTH))
     @GetMapping
     public Response<AboutUserResponseBody> getUser(@RequestParam Long userId) {
         return userService.getUser(userId);
     }
 
-    @Operation(summary = "Add new user")
+    @Operation(summary = "Add new user", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping
     public Response<User> addUser(
             @RequestBody AddUserRequestBody addUserRequestBody) {
         return userService.addUser(addUserRequestBody);
     }
 
-    @Operation(summary = "Update user")
+    @Operation(summary = "Update user", security = @SecurityRequirement(name = JWT_AUTH))
     @PutMapping
     public Response<User> updateUser(@RequestParam Long userId, @RequestBody
     AddUserRequestBody addUserRequestBody) {
         return userService.updateUser(userId, addUserRequestBody);
     }
 
-    @Operation(summary = "Delete user")
+    @Operation(summary = "Delete user", security = @SecurityRequirement(name = JWT_AUTH))
     @DeleteMapping
     public void deleteUser(@RequestParam Long userId) {
         userService.deleteUser(userId);

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/UserMapper.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/UserMapper.java
@@ -24,9 +24,11 @@ public abstract class UserMapper {
     protected PasswordEncoder passwordEncoder;
 
     @Mapping(target = "password", expression = "java(passwordEncoder.encode(addUserRequestBody.password()))")
+
     public abstract User addRequestBodyToUser(
             AddUserRequestBody addUserRequestBody);
 
+    @Mapping(target = "password", expression = "java(passwordEncoder.encode(addUserRequestBody.password()))")
     public abstract void updateUserFromAddRequestBody(
             AddUserRequestBody addUserRequestBody, @MappingTarget User user);
 

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
@@ -17,6 +17,7 @@ import pl.edu.agh.apdvbackend.use_cases.endpoint.GetUserEndpointDataWithFields;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.RemoveEndpointById;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.SaveNewEndpoint;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.UpdateEndpoint;
+import pl.edu.agh.apdvbackend.use_cases.user.FindCurrentUserId;
 
 @Service
 @RequiredArgsConstructor
@@ -35,21 +36,20 @@ public class EndpointService {
 
     private final UpdateEndpoint updateEndpoint;
 
-    public Response<List<ObjectNode>> getData(Long userId,
-                                              Long sensorId,
+    private final FindCurrentUserId findCurrentUserId;
+
+    public Response<List<ObjectNode>> getData(Long sensorId,
                                               Long limit,
                                               Long offset) {
         return Response.withOkStatus(
-                getUserEndpointData.execute(userId, sensorId, limit, offset));
+                getUserEndpointData.execute(findCurrentUserId.execute(), sensorId, limit, offset));
     }
 
-    public Response<EndpointData> getDataWithFields(Long userId,
-                                                    Long sensorId,
+    public Response<EndpointData> getDataWithFields(Long sensorId,
                                                     Long limit,
                                                     Long offset) {
         return Response.withOkStatus(
-                getUserEndpointDataWithFields.execute(userId, sensorId, limit,
-                        offset));
+                getUserEndpointDataWithFields.execute(findCurrentUserId.execute(), sensorId, limit, offset));
     }
 
     public Response<List<EndpointSummaryResponseBody>> getEndpointsList() {
@@ -66,9 +66,9 @@ public class EndpointService {
         removeEndpointById.execute(endpointId);
     }
 
-    public Response<List<UserEndpointResponseBody>> getUserEndpointsList(
-            Long userId) {
-        return Response.withOkStatus(getAllUserEndpoints.execute(userId));
+    public Response<List<UserEndpointResponseBody>> getUserEndpointsList() {
+        return Response.withOkStatus(getAllUserEndpoints.execute(
+                findCurrentUserId.execute()));
     }
 
     public Response<Endpoint> updateEndpoint(

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/FieldService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/FieldService.java
@@ -11,6 +11,7 @@ import pl.edu.agh.apdvbackend.use_cases.field.GetAllFields;
 import pl.edu.agh.apdvbackend.use_cases.field.RemoveField;
 import pl.edu.agh.apdvbackend.use_cases.field.SaveNewField;
 import pl.edu.agh.apdvbackend.use_cases.field.UpdateField;
+import pl.edu.agh.apdvbackend.use_cases.user.FindCurrentUserId;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,8 @@ public class FieldService {
 
     private final UpdateField updateField;
 
+    private final FindCurrentUserId findCurrentUserId;
+
     public Response<Field> addField(AddFieldBodyRequest addFieldBodyRequest) {
         return Response.withOkStatus(saveNewField.execute(addFieldBodyRequest));
     }
@@ -35,10 +38,9 @@ public class FieldService {
         return Response.withOkStatus(getAllFields.execute());
     }
 
-    public Response<List<Field>> getAllEnableEndpoints(Long userId,
-                                                       Long endpointId) {
+    public Response<List<Field>> getAllEnableEndpoints(Long endpointId) {
         return Response.withOkStatus(
-                getAllEnableFieldsForEndpointAndUser.execute(userId,
+                getAllEnableFieldsForEndpointAndUser.execute(findCurrentUserId.execute(),
                         endpointId));
     }
 

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/user/AddUserImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/user/AddUserImpl.java
@@ -5,6 +5,7 @@ import lombok.SneakyThrows;
 import org.springframework.stereotype.Component;
 import pl.edu.agh.apdvbackend.mappers.UserMapper;
 import pl.edu.agh.apdvbackend.models.body_models.user.AddUserRequestBody;
+import pl.edu.agh.apdvbackend.models.database.Role;
 import pl.edu.agh.apdvbackend.models.database.User;
 import pl.edu.agh.apdvbackend.repositories.UserRepository;
 import pl.edu.agh.apdvbackend.validators.UserDataValidationUtilities;
@@ -23,9 +24,10 @@ public class AddUserImpl
     @Override
     public User execute(AddUserRequestBody addUserRequestBody) {
         validateRequestBody(addUserRequestBody);
+        final var user = userMapper.addRequestBodyToUser(addUserRequestBody);
+        user.addRole(Role.USER);
 
-        return userRepository.save(
-                userMapper.addRequestBodyToUser(addUserRequestBody));
+        return userRepository.save(user);
     }
 
     @SneakyThrows

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/user/FindCurrentUserId.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/user/FindCurrentUserId.java
@@ -1,0 +1,5 @@
+package pl.edu.agh.apdvbackend.use_cases.user;
+
+public interface FindCurrentUserId {
+    Long execute();
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/user/FindCurrentUserIdImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/user/FindCurrentUserIdImpl.java
@@ -1,0 +1,27 @@
+package pl.edu.agh.apdvbackend.use_cases.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.repositories.UserRepository;
+
+@Component
+@RequiredArgsConstructor
+public class FindCurrentUserIdImpl
+        implements FindCurrentUserId {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Long execute() {
+        final var email = SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getName();
+
+        return userRepository
+                .findByEmail(email)
+                .orElseThrow()
+                .getId();
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/utilities/JwtTokenUtilsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/utilities/JwtTokenUtilsImpl.java
@@ -5,6 +5,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.models.database.Role;
 import pl.edu.agh.apdvbackend.models.database.User;
 
 @Component
@@ -33,6 +34,7 @@ public class JwtTokenUtilsImpl implements JwtTokenUtils {
                 .withExpiresAt(new Date(System.currentTimeMillis() +
                         expireTime))
                 .withClaim("id", user.getId())
+                .withClaim("roles", user.getRoles().stream().map(Role::name).toList())
                 .sign(algorithm);
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/utilities/JwtTokenUtilsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/utilities/JwtTokenUtilsImpl.java
@@ -12,9 +12,9 @@ import pl.edu.agh.apdvbackend.models.database.User;
 @RequiredArgsConstructor
 public class JwtTokenUtilsImpl implements JwtTokenUtils {
 
-    private static final int ACCESS_TOKEN_EXPIRES_TIME = 10 * 60 * 1000;
+    private static final int ACCESS_TOKEN_EXPIRES_TIME = 10 * 60 * 60 * 1000;
 
-    private static final int REFRESH_TOKEN_EXPIRES_TIME = 30 * 60 * 1000;
+    private static final int REFRESH_TOKEN_EXPIRES_TIME = 72 * 60 * 60 * 1000;
 
     private final Algorithm algorithm;
 


### PR DESCRIPTION
NIE MERGOWAĆ DOPÓKI WSZYSTKIE SUBTASKI Z APDV-9 NIE DOSTANĘ APPROVE

- Zabezpieczyłem API
   - Każdy może dostać się do logowania/rejestracji
   - Po zalogowaniu ma się dostęp do następujących endpointów GET: "/sensor/data",
                "/sensor",
                "/sensor/list",
                "/field/enable",
                "/unit/converter",
                "/unit/converter/all"
   - Reszta zabezpieczona tylko dla Admina
- W pliku `mock.sql` dodałem przykładowego admina i user'a do testów
- Testowanie API przez Swaggera również działa