### PR TITLE
APDV-94 obsługa błędów autoryzacji

### DIFF
--- a/backend/src/main/java/pl/edu/agh/apdvbackend/auth/CustomAuthorizationFilter.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/auth/CustomAuthorizationFilter.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -34,11 +35,13 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
 
     private static final String ROLES = "roles";
 
-    private static final String ERROR = "error";
-
     private static final String LOGIN_PATH = "/auth/login";
 
     private static final String REFRESH_TOKEN_PATH = "/auth/refresh-token";
+
+    private static final String DATA = "data";
+
+    private static final String ERROR = "error";
 
     private final Algorithm algorithm;
 
@@ -59,7 +62,7 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
             tryToUpdateSecurityContext(request, response, filterChain,
                     authorizationHeader);
         } catch (IOException | ServletException |
-                 JWTDecodeException exception) {
+                 JWTDecodeException | TokenExpiredException exception) {
             sendErrorResponse(response, exception);
         }
     }
@@ -103,8 +106,8 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
                                    Exception exception)
             throws IOException {
         final Map<String, String> error = new HashMap<>();
-        error.put("data", "");
-        error.put("error", exception.getMessage());
+        error.put(DATA, null);
+        error.put(ERROR, exception.getMessage());
 
         response.setStatus(FORBIDDEN.value());
         response.setContentType(APPLICATION_JSON_VALUE);

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/AuthController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/AuthController.java
@@ -1,6 +1,7 @@
 package pl.edu.agh.apdvbackend.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.auth.JWTResponse;
 import pl.edu.agh.apdvbackend.models.body_models.auth.LogInRequestBody;
@@ -36,7 +38,7 @@ public class AuthController {
         return authService.registerUser(addUserRequestBody);
     }
 
-    @Operation(summary = "Refresh token, when access token is expired")
+    @Operation(summary = "Refresh token, when access token is expired", security = @SecurityRequirement(name = JWT_AUTH))
     @PostMapping("/refresh-token")
     public Response<JWTResponse> refreshToken(
             HttpServletRequest httpServletRequest) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/exceptions/handlers/RestResponseExceptionHandler.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/exceptions/handlers/RestResponseExceptionHandler.java
@@ -1,5 +1,6 @@
 package pl.edu.agh.apdvbackend.exceptions.handlers;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import java.util.NoSuchElementException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/exceptions/handlers/RestResponseExceptionHandler.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/exceptions/handlers/RestResponseExceptionHandler.java
@@ -1,6 +1,5 @@
 package pl.edu.agh.apdvbackend.exceptions.handlers;
 
-import com.auth0.jwt.exceptions.TokenExpiredException;
 import java.util.NoSuchElementException;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;


### PR DESCRIPTION
- Dodałem proste handlowanie wyjątków autoryzacji, żeby zwracało taką strukturę jak dla innych endpointów,
- Wysyła informacje z errorem, jeżeli token nam się przedawnił, jeżeli token nie jest poprawny
- Jeżeli nie jesteśmy zalogowani, albo nie mamy uprawnień do konkretnego endpointa API, to wyrzuca tylko `403`