### PR TITLE
APDV-133 Endpoint dla widoku user'ów w panelu admina

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
     testImplementation 'com.h2database:h2'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/body_models/user/UserResponseBody.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/body_models/user/UserResponseBody.java
@@ -3,10 +3,12 @@ package pl.edu.agh.apdvbackend.models.body_models.user;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import pl.edu.agh.apdvbackend.models.body_models.group.ShortGroupResponseBody;
+import pl.edu.agh.apdvbackend.models.database.Role;
 
 public record UserResponseBody(
         @Schema(required = true) Long id,
         @Schema(required = true) String email,
+        @Schema(required = true) List<Role> roles,
         @Schema(required = true) List<ShortGroupResponseBody> groups
 ) {
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
@@ -17,7 +17,6 @@ import javax.persistence.ManyToMany;
 import javax.persistence.MapKeyJoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,7 +27,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties({"fieldParserMap", "groupEndpoints"})
-@EqualsAndHashCode
 public class Endpoint {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Field.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Field.java
@@ -15,7 +15,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,7 +24,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode
 @JsonIgnoreProperties({"groupEndpoint"})
 public class Field {
     @Id

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/FieldParser.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/FieldParser.java
@@ -7,7 +7,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,7 +16,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode
 public class FieldParser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Group.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Group.java
@@ -17,7 +17,6 @@ import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -28,7 +27,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties({"groupEndpoints"})
-@EqualsAndHashCode
 public class Group {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/GroupEndpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/GroupEndpoint.java
@@ -10,7 +10,6 @@ import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,7 +19,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @Table(name = "group_endpoint")
-@EqualsAndHashCode
 public class GroupEndpoint {
     @EmbeddedId
     private GroupEndpointKey id;

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/UnitConverter.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/UnitConverter.java
@@ -10,7 +10,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,7 +19,6 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-@EqualsAndHashCode
 public class UnitConverter {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/User.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/User.java
@@ -3,7 +3,6 @@ package pl.edu.agh.apdvbackend.models.database;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/User.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/User.java
@@ -3,6 +3,7 @@ package pl.edu.agh.apdvbackend.models.database;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -14,7 +15,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,7 +25,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @JsonIgnoreProperties({"groups", "password"})
-@EqualsAndHashCode
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/EndpointRequestBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/EndpointRequestBodyMapperTest.java
@@ -53,7 +53,7 @@ class EndpointRequestBodyMapperTest {
         final var result = mapper.toEndpoint(requestBody);
 
         // Then
-        assertEquals(expected, result);
+        assert(expected, result);
     }
 
     @Test

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/EndpointRequestBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/EndpointRequestBodyMapperTest.java
@@ -17,7 +17,7 @@ import pl.edu.agh.apdvbackend.models.body_models.field_and_parser.FieldAndParser
 import pl.edu.agh.apdvbackend.models.database.Field;
 import pl.edu.agh.apdvbackend.models.database.FieldParser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -53,7 +53,7 @@ class EndpointRequestBodyMapperTest {
         final var result = mapper.toEndpoint(requestBody);
 
         // Then
-        assert(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
@@ -84,6 +84,6 @@ class EndpointRequestBodyMapperTest {
         mapper.updateEndpoint(requestBody, endpointToUpdate);
 
         // Then
-        assertEquals(expected, endpointToUpdate);
+        assertThat(endpointToUpdate).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/EndpointResponseBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/EndpointResponseBodyMapperTest.java
@@ -17,7 +17,7 @@ import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointResponseBody;
 import pl.edu.agh.apdvbackend.models.database.Field;
 import pl.edu.agh.apdvbackend.models.database.FieldParser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -69,7 +69,7 @@ class EndpointResponseBodyMapperTest {
         final var result = mapper.toResponseBody(endpoint);
 
         // Then
-        assertEquals(expectedResult, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 
     @Test
@@ -99,6 +99,6 @@ class EndpointResponseBodyMapperTest {
         final var result = mapper.toResponseBodyList(List.of(endpoint));
 
         // Then
-        assertEquals(expectedResult, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/UserEndpointResponseBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/endpoint/UserEndpointResponseBodyMapperTest.java
@@ -9,7 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import pl.edu.agh.apdvbackend.fakes.EndpointFakes;
 import pl.edu.agh.apdvbackend.models.body_models.endpoint.UserEndpointResponseBody;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -35,7 +35,7 @@ class UserEndpointResponseBodyMapperTest {
         final var result = mapper.toResponseBody(endpoint);
 
         // Then
-        assertEquals(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
@@ -55,6 +55,6 @@ class UserEndpointResponseBodyMapperTest {
         final var result = mapper.toResponseBodyList(List.of(endpoint));
 
         // Then
-        assertEquals(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/FieldRequestBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/FieldRequestBodyMapperTest.java
@@ -15,7 +15,7 @@ import pl.edu.agh.apdvbackend.fakes.body_models.field.AddFieldRequestBodyFakes;
 import pl.edu.agh.apdvbackend.mappers.unit.UnitNameMapper;
 import pl.edu.agh.apdvbackend.models.database.FieldType;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -57,7 +57,7 @@ class FieldRequestBodyMapperTest {
         final var result = mapper.toField(addFieldRequestBody);
 
         // Then
-        assertEquals(expectedField, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedField);
     }
 
     @Test
@@ -95,6 +95,6 @@ class FieldRequestBodyMapperTest {
         mapper.updateFieldBy(addFieldRequestBody, fieldToUpdate);
 
         // Then
-        assertEquals(expectedField, fieldToUpdate);
+        assertThat(fieldToUpdate).usingRecursiveComparison().isEqualTo(expectedField);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/FieldWithoutIdMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/FieldWithoutIdMapperTest.java
@@ -12,7 +12,7 @@ import pl.edu.agh.apdvbackend.models.body_models.field.FieldWithoutId;
 import pl.edu.agh.apdvbackend.models.database.FieldType;
 import pl.edu.agh.apdvbackend.models.database.Unit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -38,7 +38,7 @@ class FieldWithoutIdMapperTest {
         final var result = mapper.fieldToWithoutId(field);
 
         // Then
-        assertEquals(expectedFieldWithoutId, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedFieldWithoutId);
     }
 
     @Test
@@ -59,6 +59,6 @@ class FieldWithoutIdMapperTest {
         final var result = mapper.fieldsToWithoutIdList(fields);
 
         // Then
-        assertEquals(expectedFieldsWithoutId, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedFieldsWithoutId);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/IdsToFieldsMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/IdsToFieldsMapperTest.java
@@ -10,8 +10,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import pl.edu.agh.apdvbackend.fakes.FieldFakes;
 import pl.edu.agh.apdvbackend.use_cases.field.GetField;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -44,6 +44,6 @@ class IdsToFieldsMapperTest {
         final var result = mapper.toFields(fieldIds);
 
         // Then
-        assertEquals(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldAndParserKeyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldAndParserKeyMapperTest.java
@@ -15,7 +15,7 @@ import pl.edu.agh.apdvbackend.fakes.body_models.field_and_parser.FieldAndParserK
 import pl.edu.agh.apdvbackend.use_cases.field.GetField;
 import pl.edu.agh.apdvbackend.use_cases.field_parser.GetFieldParser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -56,6 +56,6 @@ class FieldAndParserKeyMapperTest {
         final var result = mapper.toMap(List.of(fieldAndParserKey));
 
         // Then
-        assertEquals(expectedResult, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldParserMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldParserMapperTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import pl.edu.agh.apdvbackend.fakes.FieldParserFakes;
 import pl.edu.agh.apdvbackend.models.body_models.field_parser.FieldParserRequestBody;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -31,7 +31,7 @@ class FieldParserMapperTest {
         final var result = mapper.addRequestBodyToFieldParser(requestBody);
 
         // Then
-        assertEquals(expectedFieldParser, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedFieldParser);
     }
 
     @Test
@@ -53,6 +53,6 @@ class FieldParserMapperTest {
         mapper.updateFieldParserFromAddRequestBody(requestBody, fieldToUpdate);
 
         // Then
-        assertEquals(expectedField, fieldToUpdate);
+        assertThat(fieldToUpdate).usingRecursiveComparison().isEqualTo(expectedField);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/group/add_group/GroupRequestBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/group/add_group/GroupRequestBodyMapperTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import pl.edu.agh.apdvbackend.fakes.GroupFakes;
 import pl.edu.agh.apdvbackend.models.body_models.group.GroupRequestBody;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
@@ -24,17 +24,13 @@ class GroupRequestBodyMapperTest {
         // Given
         final var groupName = "groupName";
         final var requestBody = new GroupRequestBody(groupName);
-        final var expectedResult = GroupFakes.builder()
-                .id(null)
-                .name(groupName)
-                .usersInGroup(new HashSet<>())
-                .groupEndpoints(new ArrayList<>())
-                .build();
+        final var expectedResult = GroupFakes.builder().id(null).name(groupName).usersInGroup(new HashSet<>())
+                .groupEndpoints(new ArrayList<>()).build();
 
         // When
         final var result = mapper.toGroup(requestBody);
 
         // Then
-        assertEquals(expectedResult, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/group_endpoint/GroupEndpointMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/group_endpoint/GroupEndpointMapperTest.java
@@ -18,7 +18,7 @@ import pl.edu.agh.apdvbackend.models.body_models.group.GroupEndpointRequestBody;
 import pl.edu.agh.apdvbackend.models.database.Field;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetEndpoint;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
@@ -75,7 +75,7 @@ class GroupEndpointMapperTest {
         final var result = mapper.toEndpointGroup(requestBody, group);
 
         // Then
-        assertEquals(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
@@ -119,6 +119,6 @@ class GroupEndpointMapperTest {
         final var result = mapper.toGroupEndpointList(requestBodies, group);
 
         // Then
-        assertEquals(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/unit/UnitConverterRequestBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/unit/UnitConverterRequestBodyMapperTest.java
@@ -15,6 +15,7 @@ import pl.edu.agh.apdvbackend.models.body_models.unit_converter.UnitConverterReq
 import pl.edu.agh.apdvbackend.models.database.MathOperation;
 import pl.edu.agh.apdvbackend.repositories.UnitRepository;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
@@ -61,7 +62,7 @@ class UnitConverterRequestBodyMapperTest {
         final var result = mapper.toUnitConverter(addUnitConverterRequestBody);
 
         // Then
-        assertEquals(expectedResult, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 
     @Test
@@ -102,6 +103,6 @@ class UnitConverterRequestBodyMapperTest {
         mapper.updateUnitConverter(addUnitConverterRequestBody, unitConverterToUpdate);
 
         // Then
-        assertEquals(expectedResult, unitConverterToUpdate);
+        assertThat(unitConverterToUpdate).usingRecursiveComparison().isEqualTo(expectedResult);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/unit/UnitConverterRequestBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/unit/UnitConverterRequestBodyMapperTest.java
@@ -16,7 +16,6 @@ import pl.edu.agh.apdvbackend.models.database.MathOperation;
 import pl.edu.agh.apdvbackend.repositories.UnitRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/unit/UnitNameMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/unit/UnitNameMapperTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import pl.edu.agh.apdvbackend.fakes.UnitFakes;
 import pl.edu.agh.apdvbackend.repositories.UnitRepository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.doReturn;
 
@@ -41,7 +41,7 @@ class UnitNameMapperTest {
         final var result = mapper.toUnit(unitNameOptional);
 
         // Then
-        assertEquals(unit, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(unit);
     }
 
     @Test

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/user/UserMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/user/UserMapperTest.java
@@ -10,7 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import pl.edu.agh.apdvbackend.fakes.UserFakes;
 import pl.edu.agh.apdvbackend.models.body_models.user.UserRequestBody;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
@@ -42,7 +42,7 @@ class UserMapperTest {
         final var result = mapper.toUser(userRequestBody);
 
         // Then
-        assertEquals(expected, result);
+        assertThat(result).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
@@ -68,6 +68,6 @@ class UserMapperTest {
         mapper.updateUser(userRequestBody, userToUpdate);
 
         // Then
-        assertEquals(expected, userToUpdate);
+        assertThat(userToUpdate).usingRecursiveComparison().isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/user/UserResponseBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/user/UserResponseBodyMapperTest.java
@@ -14,6 +14,7 @@ import pl.edu.agh.apdvbackend.mappers.group.short_group.ShortGroupMapper;
 import pl.edu.agh.apdvbackend.models.body_models.group.ShortGroupResponseBody;
 import pl.edu.agh.apdvbackend.models.body_models.user.UserResponseBody;
 import pl.edu.agh.apdvbackend.models.database.Group;
+import pl.edu.agh.apdvbackend.models.database.Role;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -33,14 +34,16 @@ class UserResponseBodyMapperTest {
         // Given
         final var id = 34L;
         final var email = "email@test.com";
+        final var roles = Set.of(Role.ADMIN);
         final Set<Group> groups = Collections.emptySet();
         final List<ShortGroupResponseBody> shortGroups = Collections.emptyList();
         final var user = UserFakes.builder()
                 .id(id)
                 .email(email)
                 .groups(groups)
+                .roles(roles)
                 .build();
-        final var expected = new UserResponseBody(id, email, shortGroups);
+        final var expected = new UserResponseBody(id, email, roles.stream().toList(), shortGroups);
 
         doReturn(shortGroups).when(shortGroupMapper).toShortGroupList(groups.stream().toList());
 
@@ -56,14 +59,18 @@ class UserResponseBodyMapperTest {
         // Given
         final var id = 34L;
         final var email = "email@test.com";
+        final var roles = Set.of(Role.ADMIN);
         final Set<Group> groups = Collections.emptySet();
         final List<ShortGroupResponseBody> shortGroups = Collections.emptyList();
         final var user = UserFakes.builder()
                 .id(id)
                 .email(email)
                 .groups(groups)
+                .roles(roles)
                 .build();
-        final var expected = List.of(new UserResponseBody(id, email, shortGroups));
+        final var expected = List.of(
+                new UserResponseBody(id, email, roles.stream().toList(), shortGroups)
+        );
 
         doReturn(shortGroups).when(shortGroupMapper).toShortGroupList(groups.stream().toList());
 


### PR DESCRIPTION
Postanowiłem przerobić API `GET /user/all` i dodałem tam `UserResponseBody` informacje o rolach.

Przy okazji zorientowałem się, że mamy poważnego buga i połowa backendu nie działała :crying_cat_face:
Przyczyną tego bug'a było `override` metod `equals` i `hashCode` dla modeli bazodanowych, nie powinno się tego robić, bo może to dojść do zapętlenia
