### PR TITLE
APDV-141 Improve endpoint API

### DIFF
--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
@@ -67,6 +67,15 @@ public class EndpointController {
     }
 
     @Operation(
+            summary = "Get endpoint summary with fields information",
+            security = @SecurityRequirement(name = JWT_AUTH)
+    )
+    @GetMapping("/summary")
+    public Response<EndpointResponseBody> getEndpointSummary(@RequestParam Long endpointId) {
+        return endpointService.getEndpointSummary(endpointId);
+    }
+
+    @Operation(
             summary = "Get all endpoints list with fields information",
             security = @SecurityRequirement(name = JWT_AUTH)
     )

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/EndpointController.java
@@ -98,7 +98,7 @@ public class EndpointController {
             security = @SecurityRequirement(name = JWT_AUTH)
     )
     @PutMapping
-    public Response<Endpoint> updateEndpoint(
+    public Response<EndpointResponseBody> updateEndpoint(
             @RequestBody EndpointRequestBody endpointRequestBody,
             @RequestParam Long endpointId
     ) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldAndParserKeyMapper.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldAndParserKeyMapper.java
@@ -9,7 +9,7 @@ import pl.edu.agh.apdvbackend.models.body_models.field_and_parser.FieldAndParser
 import pl.edu.agh.apdvbackend.models.database.Field;
 import pl.edu.agh.apdvbackend.models.database.FieldParser;
 import pl.edu.agh.apdvbackend.use_cases.field.GetField;
-import pl.edu.agh.apdvbackend.use_cases.field_parser.GetFieldParser;
+import pl.edu.agh.apdvbackend.use_cases.field_parser.GetOrSaveFieldParser;
 
 @Mapper(componentModel = "spring")
 public abstract class FieldAndParserKeyMapper {
@@ -18,11 +18,14 @@ public abstract class FieldAndParserKeyMapper {
     private GetField getField;
 
     @Autowired
-    private GetFieldParser getFieldParser;
+    private GetOrSaveFieldParser getOrSaveFieldParser;
 
     public Map<Field, FieldParser> toMap(List<FieldAndParserKey> fieldAndParserKeys) {
         return fieldAndParserKeys.stream().collect(
-                Collectors.toMap(key -> getField.execute(key.fieldId()), key -> getFieldParser.execute(key.parserId()))
+                Collectors.toMap(
+                        key -> getField.execute(key.fieldId()),
+                        key -> getOrSaveFieldParser.execute(key.fieldParserPath())
+                )
         );
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/body_models/field_and_parser/FieldAndParserKey.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/body_models/field_and_parser/FieldAndParserKey.java
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FieldAndParserKey(
         @Schema(required = true) Long fieldId,
-        @Schema(required = true) Long parserId
+        @Schema(required = true) String fieldParserPath
 ) {
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/repositories/FieldParserRepository.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/repositories/FieldParserRepository.java
@@ -1,9 +1,11 @@
 package pl.edu.agh.apdvbackend.repositories;
 
+import java.util.Optional;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 import pl.edu.agh.apdvbackend.models.database.FieldParser;
 
 @Repository
 public interface FieldParserRepository extends CrudRepository<FieldParser, Long> {
+    Optional<FieldParser> findByPath(String path);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
@@ -12,6 +12,7 @@ import pl.edu.agh.apdvbackend.models.body_models.endpoint.UserEndpointResponseBo
 import pl.edu.agh.apdvbackend.models.database.Endpoint;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetAllEndpointSummaries;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetAllUserEndpoints;
+import pl.edu.agh.apdvbackend.use_cases.endpoint.GetEndpointSummary;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetUserEndpointData;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.GetUserEndpointDataWithFields;
 import pl.edu.agh.apdvbackend.use_cases.endpoint.RemoveEndpointById;
@@ -26,6 +27,7 @@ public class EndpointService {
     private final GetUserEndpointDataWithFields getUserEndpointDataWithFields;
     private final SaveNewEndpoint saveNewEndpoint;
     private final RemoveEndpointById removeEndpointById;
+    private final GetEndpointSummary getEndpointSummary;
     private final GetAllEndpointSummaries getAllEndpointSummaries;
     private final GetAllUserEndpoints getAllUserEndpoints;
     private final UpdateEndpoint updateEndpoint;
@@ -47,6 +49,10 @@ public class EndpointService {
         return Response.withOkStatus(
                 getUserEndpointDataWithFields.execute(findCurrentUserId.execute(), sensorId, limit, offset)
         );
+    }
+
+    public Response<EndpointResponseBody> getEndpointSummary(Long endpointId) {
+        return Response.withOkStatus(getEndpointSummary.execute(endpointId));
     }
 
     public Response<List<EndpointResponseBody>> getEndpointsList() {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/EndpointService.java
@@ -65,7 +65,7 @@ public class EndpointService {
         return Response.withOkStatus(getAllUserEndpoints.execute(findCurrentUserId.execute()));
     }
 
-    public Response<Endpoint> updateEndpoint(
+    public Response<EndpointResponseBody> updateEndpoint(
             EndpointRequestBody endpointRequestBody,
             Long endpointId
     ) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetEndpointSummary.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetEndpointSummary.java
@@ -1,0 +1,7 @@
+package pl.edu.agh.apdvbackend.use_cases.endpoint;
+
+import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointResponseBody;
+
+public interface GetEndpointSummary {
+    EndpointResponseBody execute(Long endpointId);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetEndpointSummaryImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/GetEndpointSummaryImpl.java
@@ -1,0 +1,20 @@
+package pl.edu.agh.apdvbackend.use_cases.endpoint;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.mappers.endpoint.EndpointResponseBodyMapper;
+import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointResponseBody;
+
+@Component
+@RequiredArgsConstructor
+public class GetEndpointSummaryImpl implements GetEndpointSummary {
+
+    private final GetEndpoint getEndpoint;
+    private final EndpointResponseBodyMapper mapper;
+
+    @Override
+    public EndpointResponseBody execute(Long endpointId) {
+        final var endpoint = getEndpoint.execute(endpointId);
+        return mapper.toResponseBody(endpoint);
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/UpdateEndpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/UpdateEndpoint.java
@@ -1,8 +1,8 @@
 package pl.edu.agh.apdvbackend.use_cases.endpoint;
 
 import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Endpoint;
+import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointResponseBody;
 
 public interface UpdateEndpoint {
-    Endpoint execute(EndpointRequestBody endpointRequestBody, Long endpointId);
+    EndpointResponseBody execute(EndpointRequestBody endpointRequestBody, Long endpointId);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/UpdateEndpointImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/endpoint/UpdateEndpointImpl.java
@@ -3,8 +3,9 @@ package pl.edu.agh.apdvbackend.use_cases.endpoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import pl.edu.agh.apdvbackend.mappers.endpoint.EndpointRequestBodyMapper;
+import pl.edu.agh.apdvbackend.mappers.endpoint.EndpointResponseBodyMapper;
 import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Endpoint;
+import pl.edu.agh.apdvbackend.models.body_models.endpoint.EndpointResponseBody;
 import pl.edu.agh.apdvbackend.repositories.EndpointRepository;
 
 @Component
@@ -14,16 +15,18 @@ public class UpdateEndpointImpl implements UpdateEndpoint {
     private final GetEndpoint getEndpoint;
     private final EndpointRepository endpointRepository;
     private final EndpointRequestBodyMapper endpointRequestBodyMapper;
+    private final EndpointResponseBodyMapper mapper;
 
     @Override
-    public Endpoint execute(
+    public EndpointResponseBody execute(
             EndpointRequestBody endpointRequestBody,
             Long endpointId
     ) {
         final var endpoint = getEndpoint.execute(endpointId);
 
         endpointRequestBodyMapper.updateEndpoint(endpointRequestBody, endpoint);
+        final var savedEndpoint = endpointRepository.save(endpoint);
 
-        return endpointRepository.save(endpoint);
+        return mapper.toResponseBody(savedEndpoint);
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field_parser/GetOrSaveFieldParser.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field_parser/GetOrSaveFieldParser.java
@@ -1,0 +1,7 @@
+package pl.edu.agh.apdvbackend.use_cases.field_parser;
+
+import pl.edu.agh.apdvbackend.models.database.FieldParser;
+
+public interface GetOrSaveFieldParser {
+    FieldParser execute(String fieldPath);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field_parser/GetOrSaveFieldParserImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field_parser/GetOrSaveFieldParserImpl.java
@@ -1,0 +1,23 @@
+package pl.edu.agh.apdvbackend.use_cases.field_parser;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.models.body_models.field_parser.FieldParserRequestBody;
+import pl.edu.agh.apdvbackend.models.database.FieldParser;
+import pl.edu.agh.apdvbackend.repositories.FieldParserRepository;
+
+@Component
+@RequiredArgsConstructor
+public class GetOrSaveFieldParserImpl implements GetOrSaveFieldParser {
+
+    private final FieldParserRepository repository;
+
+    private final SaveNewFieldParser saveNewFieldParser;
+
+    @Override
+    public FieldParser execute(String fieldParserPath) {
+        return repository
+                .findByPath(fieldParserPath)
+                .orElseGet(() -> saveNewFieldParser.execute(new FieldParserRequestBody(fieldParserPath)));
+    }
+}

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/fakes/body_models/field_and_parser/FieldAndParserKeyFakes.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/fakes/body_models/field_and_parser/FieldAndParserKeyFakes.java
@@ -8,8 +8,8 @@ public class FieldAndParserKeyFakes {
     @Builder
     private static FieldAndParserKey buildNewFieldAndParserKey(
             Long fieldId,
-            Long parserId
+            String fieldParserPath
     ) {
-        return new FieldAndParserKey(fieldId, parserId);
+        return new FieldAndParserKey(fieldId, fieldParserPath);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldAndParserKeyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field_parser/FieldAndParserKeyMapperTest.java
@@ -13,7 +13,7 @@ import pl.edu.agh.apdvbackend.fakes.FieldFakes;
 import pl.edu.agh.apdvbackend.fakes.FieldParserFakes;
 import pl.edu.agh.apdvbackend.fakes.body_models.field_and_parser.FieldAndParserKeyFakes;
 import pl.edu.agh.apdvbackend.use_cases.field.GetField;
-import pl.edu.agh.apdvbackend.use_cases.field_parser.GetFieldParser;
+import pl.edu.agh.apdvbackend.use_cases.field_parser.GetOrSaveFieldParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +25,7 @@ class FieldAndParserKeyMapperTest {
     private GetField getField;
 
     @MockBean
-    private GetFieldParser getFieldParser;
+    private GetOrSaveFieldParser getOrSaveFieldParser;
 
     @Autowired
     private FieldAndParserKeyMapper mapper;
@@ -35,9 +35,10 @@ class FieldAndParserKeyMapperTest {
         // Given
         final var fieldId = 65L;
         final var parserId = 87L;
+        final var fieldParserPath = "/fake/field/parser/path";
         final var fieldAndParserKey = FieldAndParserKeyFakes.builder()
                 .fieldId(fieldId)
-                .parserId(parserId)
+                .fieldParserPath(fieldParserPath)
                 .build();
         final var field = FieldFakes.builder()
                 .id(fieldId)
@@ -50,7 +51,7 @@ class FieldAndParserKeyMapperTest {
         Mockito.doReturn(field)
                 .when(getField).execute(fieldId);
         Mockito.doReturn(fieldParser)
-                .when(getFieldParser).execute(parserId);
+                .when(getOrSaveFieldParser).execute(fieldParserPath);
 
         // When
         final var result = mapper.toMap(List.of(fieldAndParserKey));


### PR DESCRIPTION
- Nowy endpoint `GET /sensor/summary`, która zwraca dane z pojedynczego `Endpoint'a` w sposób podobny jak `GET /sensor/list/all`,
- W `PUT /sensor` zmieniono na wejściu `parserId` -> `fieldParserPath`, jeżeli nie będzie danej ścieżki zapisanej w bazie, to utworzy nową,
- `PUT /sensor` zwraca ten sam wynik co `GET /sensor/summary`.