### PR TITLE
APDV-147 Błąd przy usuwaniu endpointa i fielda

### DIFF
--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 import pl.edu.agh.apdvbackend.models.database.Field;
 import pl.edu.agh.apdvbackend.services.FieldService;
 
@@ -33,7 +34,7 @@ public class FieldController {
             security = @SecurityRequirement(name = JWT_AUTH)
     )
     @PostMapping
-    public Response<Field> addField(@RequestBody FieldRequestBody fieldRequestBody) {
+    public Response<FieldResponseBody> addField(@RequestBody FieldRequestBody fieldRequestBody) {
         return fieldService.addField(fieldRequestBody);
     }
 
@@ -42,7 +43,7 @@ public class FieldController {
             security = @SecurityRequirement(name = JWT_AUTH)
     )
     @GetMapping
-    public Response<List<Field>> getAllFields() {
+    public Response<List<FieldResponseBody>> getAllFields() {
         return fieldService.getAllFields();
     }
 
@@ -51,7 +52,7 @@ public class FieldController {
             security = @SecurityRequirement(name = JWT_AUTH)
     )
     @GetMapping("/enable")
-    public Response<List<Field>> getAllEnableEndpoints(@RequestParam Long endpointId) {
+    public Response<List<FieldResponseBody>> getAllEnableEndpoints(@RequestParam Long endpointId) {
         return fieldService.getAllEnableEndpoints(endpointId);
     }
 
@@ -69,7 +70,7 @@ public class FieldController {
             security = @SecurityRequirement(name = JWT_AUTH)
     )
     @PutMapping
-    public Response<Field> updateField(
+    public Response<FieldResponseBody> updateField(
             @RequestParam Long fieldId,
             @RequestBody FieldRequestBody fieldRequestBody
     ) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/controllers/FieldController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
-import pl.edu.agh.apdvbackend.models.database.Field;
 import pl.edu.agh.apdvbackend.services.FieldService;
 
 import static pl.edu.agh.apdvbackend.configs.SwaggerConfig.JWT_AUTH;

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/field/FieldResponseBodyMapper.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/mappers/field/FieldResponseBodyMapper.java
@@ -1,0 +1,13 @@
+package pl.edu.agh.apdvbackend.mappers.field;
+
+import java.util.List;
+import org.mapstruct.Mapper;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
+import pl.edu.agh.apdvbackend.models.database.Field;
+
+@Mapper(componentModel = "spring")
+public interface FieldResponseBodyMapper {
+    FieldResponseBody toResponseBody(Field field);
+
+    List<FieldResponseBody> toResponseBodyList(List<Field> fields);
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/body_models/field/FieldResponseBody.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/body_models/field/FieldResponseBody.java
@@ -1,0 +1,12 @@
+package pl.edu.agh.apdvbackend.models.body_models.field;
+
+import pl.edu.agh.apdvbackend.models.database.FieldType;
+import pl.edu.agh.apdvbackend.models.database.Unit;
+
+public record FieldResponseBody(
+        Long id,
+        String label,
+        FieldType fieldType,
+        Unit unit
+) {
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
@@ -61,4 +61,8 @@ public class Endpoint {
     public void removeField(Field field) {
         fieldParserMap.remove(field);
     }
+
+    public void removeFieldParser(FieldParser fieldParserToRemove) {
+        fieldParserMap.values().remove(fieldParserToRemove);
+    }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
@@ -42,7 +42,7 @@ public class Endpoint {
     @Schema(required = true)
     private String sensorUrl;
 
-    @ManyToMany(cascade = CascadeType.ALL)
+    @ManyToMany
     @JoinTable(name = "fields_parser_mapping",
             joinColumns = {
                     @JoinColumn(name = "endpoint_id", referencedColumnName = "id")},
@@ -51,7 +51,7 @@ public class Endpoint {
     @MapKeyJoinColumn(name = "field_id")
     private Map<Field, FieldParser> fieldParserMap = new HashMap<>();
 
-    @OneToMany(mappedBy = "endpoint")
+    @OneToMany(mappedBy = "endpoint", cascade = CascadeType.ALL)
     private Set<GroupEndpoint> groupEndpoints = new HashSet<>();
 
     public String getFieldPath(Field field) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Endpoint.java
@@ -57,4 +57,8 @@ public class Endpoint {
     public String getFieldPath(Field field) {
         return fieldParserMap.get(field).getPath();
     }
+
+    public void removeField(Field field) {
+        fieldParserMap.remove(field);
+    }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Field.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Field.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -43,6 +44,6 @@ public class Field {
     @JoinColumn(name = "unit_id")
     private Unit unit;
 
-    @ManyToMany(mappedBy = "enableFields")
+    @ManyToMany(mappedBy = "enableFields", cascade = CascadeType.ALL)
     private List<GroupEndpoint> groupEndpoint = new ArrayList<>();
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Field.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/Field.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -44,6 +43,9 @@ public class Field {
     @JoinColumn(name = "unit_id")
     private Unit unit;
 
-    @ManyToMany(mappedBy = "enableFields", cascade = CascadeType.ALL)
+    @ManyToMany(mappedBy = "enableFields")
     private List<GroupEndpoint> groupEndpoint = new ArrayList<>();
+
+    @ManyToMany(mappedBy = "fieldParserMap")
+    private List<Endpoint> endpoints = new ArrayList<>();
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/FieldParser.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/FieldParser.java
@@ -1,11 +1,14 @@
 package pl.edu.agh.apdvbackend.models.database;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,4 +28,8 @@ public class FieldParser {
     @Schema(required = true)
     @Column(unique = true)
     private String path;
+
+    @JsonIgnore
+    @ManyToMany(mappedBy = "fieldParserMap")
+    private List<Endpoint> endpoints;
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/GroupEndpoint.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/models/database/GroupEndpoint.java
@@ -41,4 +41,8 @@ public class GroupEndpoint {
             inverseJoinColumns = {@JoinColumn(name = "field_id")}
     )
     private List<Field> enableFields = new ArrayList<>();
+
+    public void removeField(Field field) {
+        enableFields.remove(field);
+    }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/services/FieldService.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/services/FieldService.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import pl.edu.agh.apdvbackend.models.body_models.Response;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Field;
-import pl.edu.agh.apdvbackend.use_cases.field.GetAllEnableFieldsForEndpointAndUser;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
+import pl.edu.agh.apdvbackend.use_cases.field.GetAllEnableFieldsAsResponseBody;
 import pl.edu.agh.apdvbackend.use_cases.field.GetAllFields;
 import pl.edu.agh.apdvbackend.use_cases.field.RemoveField;
 import pl.edu.agh.apdvbackend.use_cases.field.SaveNewField;
@@ -19,22 +19,22 @@ public class FieldService {
 
     private final SaveNewField saveNewField;
     private final GetAllFields getAllFields;
-    private final GetAllEnableFieldsForEndpointAndUser getAllEnableFieldsForEndpointAndUser;
+    private final GetAllEnableFieldsAsResponseBody getAllEnableFieldsAsResponseBody;
     private final RemoveField removeField;
     private final UpdateField updateField;
     private final FindCurrentUserId findCurrentUserId;
 
-    public Response<Field> addField(FieldRequestBody fieldRequestBody) {
+    public Response<FieldResponseBody> addField(FieldRequestBody fieldRequestBody) {
         return Response.withOkStatus(saveNewField.execute(fieldRequestBody));
     }
 
-    public Response<List<Field>> getAllFields() {
+    public Response<List<FieldResponseBody>> getAllFields() {
         return Response.withOkStatus(getAllFields.execute());
     }
 
-    public Response<List<Field>> getAllEnableEndpoints(Long endpointId) {
+    public Response<List<FieldResponseBody>> getAllEnableEndpoints(Long endpointId) {
         return Response.withOkStatus(
-                getAllEnableFieldsForEndpointAndUser.execute(findCurrentUserId.execute(), endpointId)
+                getAllEnableFieldsAsResponseBody.execute(findCurrentUserId.execute(), endpointId)
         );
     }
 
@@ -42,7 +42,7 @@ public class FieldService {
         removeField.execute(fieldId);
     }
 
-    public Response<Field> updateField(
+    public Response<FieldResponseBody> updateField(
             Long fieldId,
             FieldRequestBody fieldRequestBody
     ) {

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsAsResponseBody.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsAsResponseBody.java
@@ -3,6 +3,6 @@ package pl.edu.agh.apdvbackend.use_cases.field;
 import java.util.List;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 
-public interface GetAllFields {
-    List<FieldResponseBody> execute();
+public interface GetAllEnableFieldsAsResponseBody {
+    List<FieldResponseBody> execute(Long userId, Long endpointId);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsAsResponseBodyImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllEnableFieldsAsResponseBodyImpl.java
@@ -1,0 +1,22 @@
+package pl.edu.agh.apdvbackend.use_cases.field;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.mappers.field.FieldResponseBodyMapper;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllEnableFieldsAsResponseBodyImpl implements GetAllEnableFieldsAsResponseBody {
+
+    private final GetAllEnableFieldsForEndpointAndUser getAllEnableFieldsForEndpointAndUser;
+    private final FieldResponseBodyMapper fieldResponseBodyMapper;
+
+    @Override
+    public List<FieldResponseBody> execute(Long userId, Long endpointId) {
+        return fieldResponseBodyMapper.toResponseBodyList(
+                getAllEnableFieldsForEndpointAndUser.execute(userId, endpointId)
+        );
+    }
+}

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllFieldsImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/GetAllFieldsImpl.java
@@ -3,7 +3,8 @@ package pl.edu.agh.apdvbackend.use_cases.field;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import pl.edu.agh.apdvbackend.models.database.Field;
+import pl.edu.agh.apdvbackend.mappers.field.FieldResponseBodyMapper;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 import pl.edu.agh.apdvbackend.repositories.FieldRepository;
 import pl.edu.agh.apdvbackend.utilities.ListUtilities;
 
@@ -14,9 +15,11 @@ public class GetAllFieldsImpl
 
     private final ListUtilities listUtilities;
     private final FieldRepository fieldRepository;
+    private final FieldResponseBodyMapper fieldResponseBodyMapper;
 
     @Override
-    public List<Field> execute() {
-        return listUtilities.iterableToList(fieldRepository.findAll());
+    public List<FieldResponseBody> execute() {
+        final var fields = listUtilities.iterableToList(fieldRepository.findAll());
+        return fieldResponseBodyMapper.toResponseBodyList(fields);
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/RemoveFieldImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/RemoveFieldImpl.java
@@ -2,16 +2,45 @@ package pl.edu.agh.apdvbackend.use_cases.field;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.models.database.Field;
+import pl.edu.agh.apdvbackend.repositories.EndpointRepository;
 import pl.edu.agh.apdvbackend.repositories.FieldRepository;
+import pl.edu.agh.apdvbackend.repositories.GroupEndpointRepository;
 
 @Component
 @RequiredArgsConstructor
 public class RemoveFieldImpl implements RemoveField {
 
     private final FieldRepository fieldRepository;
+    private final EndpointRepository endpointRepository;
+    private final GroupEndpointRepository groupEndpointRepository;
 
     @Override
     public void execute(Long fieldId) {
+        final var field = fieldRepository
+                .findById(fieldId)
+                .orElseThrow();
+
+        removeFieldFromEndpoint(field);
+        removeFieldFromGroupEndpoint(field);
         fieldRepository.deleteById(fieldId);
+    }
+
+    private void removeFieldFromEndpoint(Field field) {
+        final var endpointsWithRemovedField = field
+                .getEndpoints()
+                .stream()
+                .peek(endpoint -> endpoint.removeField(field))
+                .toList();
+        endpointRepository.saveAll(endpointsWithRemovedField);
+    }
+
+    private void removeFieldFromGroupEndpoint(Field field) {
+        final var groupEndpointsWithRemovedField = field
+                .getGroupEndpoint()
+                .stream()
+                .peek(groupEndpoint -> groupEndpoint.removeField(field))
+                .toList();
+        groupEndpointRepository.saveAll(groupEndpointsWithRemovedField);
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/SaveNewField.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/SaveNewField.java
@@ -1,8 +1,8 @@
 package pl.edu.agh.apdvbackend.use_cases.field;
 
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Field;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 
 public interface SaveNewField {
-    Field execute(FieldRequestBody fieldRequestBody);
+    FieldResponseBody execute(FieldRequestBody fieldRequestBody);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/SaveNewFieldImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/SaveNewFieldImpl.java
@@ -3,8 +3,9 @@ package pl.edu.agh.apdvbackend.use_cases.field;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import pl.edu.agh.apdvbackend.mappers.field.FieldRequestBodyMapper;
+import pl.edu.agh.apdvbackend.mappers.field.FieldResponseBodyMapper;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Field;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 import pl.edu.agh.apdvbackend.repositories.FieldRepository;
 import pl.edu.agh.apdvbackend.use_cases.unit.SaveUnitByNameIfNotExist;
 
@@ -15,11 +16,13 @@ public class SaveNewFieldImpl implements SaveNewField {
     private final FieldRepository fieldRepository;
     private final SaveUnitByNameIfNotExist saveUnitByNameIfNotExist;
     private final FieldRequestBodyMapper mapper;
+    private final FieldResponseBodyMapper fieldResponseBodyMapper;
 
     @Override
-    public Field execute(FieldRequestBody requestBody) {
+    public FieldResponseBody execute(FieldRequestBody requestBody) {
         requestBody.unitName().ifPresent(saveUnitByNameIfNotExist::execute);
 
-        return fieldRepository.save(mapper.toField(requestBody));
+        final var savedField = fieldRepository.save(mapper.toField(requestBody));
+        return fieldResponseBodyMapper.toResponseBody(savedField);
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/UpdateField.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/UpdateField.java
@@ -1,8 +1,8 @@
 package pl.edu.agh.apdvbackend.use_cases.field;
 
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Field;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 
 public interface UpdateField {
-    Field execute(Long fieldId, FieldRequestBody fieldRequestBody);
+    FieldResponseBody execute(Long fieldId, FieldRequestBody fieldRequestBody);
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/UpdateFieldImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field/UpdateFieldImpl.java
@@ -3,8 +3,9 @@ package pl.edu.agh.apdvbackend.use_cases.field;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import pl.edu.agh.apdvbackend.mappers.field.FieldRequestBodyMapper;
+import pl.edu.agh.apdvbackend.mappers.field.FieldResponseBodyMapper;
 import pl.edu.agh.apdvbackend.models.body_models.field.FieldRequestBody;
-import pl.edu.agh.apdvbackend.models.database.Field;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
 import pl.edu.agh.apdvbackend.repositories.FieldRepository;
 import pl.edu.agh.apdvbackend.use_cases.unit.SaveUnitByNameIfNotExist;
 
@@ -15,9 +16,10 @@ public class UpdateFieldImpl implements UpdateField {
     private final FieldRepository fieldRepository;
     private final SaveUnitByNameIfNotExist saveUnitByNameIfNotExist;
     private final FieldRequestBodyMapper mapper;
+    private final FieldResponseBodyMapper fieldResponseBodyMapper;
 
     @Override
-    public Field execute(
+    public FieldResponseBody execute(
             Long fieldId,
             FieldRequestBody fieldRequestBody
     ) {
@@ -28,6 +30,6 @@ public class UpdateFieldImpl implements UpdateField {
         fieldRequestBody.unitName().ifPresent(saveUnitByNameIfNotExist::execute);
         mapper.updateFieldBy(fieldRequestBody, updatingField);
 
-        return fieldRepository.save(updatingField);
+        return fieldResponseBodyMapper.toResponseBody(fieldRepository.save(updatingField));
     }
 }

--- a/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field_parser/RemoveFieldParserImpl.java
+++ b/backend/src/main/java/pl/edu/agh/apdvbackend/use_cases/field_parser/RemoveFieldParserImpl.java
@@ -2,16 +2,34 @@ package pl.edu.agh.apdvbackend.use_cases.field_parser;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import pl.edu.agh.apdvbackend.models.database.FieldParser;
+import pl.edu.agh.apdvbackend.repositories.EndpointRepository;
 import pl.edu.agh.apdvbackend.repositories.FieldParserRepository;
 
 @Component
 @RequiredArgsConstructor
 public class RemoveFieldParserImpl implements RemoveFieldParser {
 
+    private final EndpointRepository endpointRepository;
     private final FieldParserRepository fieldParserRepository;
 
     @Override
     public void execute(Long fieldParserId) {
+        final var fieldParser = fieldParserRepository
+                .findById(fieldParserId)
+                .orElseThrow();
+
+        removeFieldParserFromEndpoint(fieldParser);
+
         fieldParserRepository.deleteById(fieldParserId);
+    }
+
+    private void removeFieldParserFromEndpoint(FieldParser fieldParser) {
+        final var endpointsWithRemovedFieldParser = fieldParser
+                .getEndpoints()
+                .stream()
+                .peek(endpoint -> endpoint.removeFieldParser(fieldParser))
+                .toList();
+        endpointRepository.saveAll(endpointsWithRemovedFieldParser);
     }
 }

--- a/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/FieldResponseBodyMapperTest.java
+++ b/backend/src/test/java/pl/edu/agh/apdvbackend/mappers/field/FieldResponseBodyMapperTest.java
@@ -1,0 +1,63 @@
+package pl.edu.agh.apdvbackend.mappers.field;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import pl.edu.agh.apdvbackend.fakes.FieldFakes;
+import pl.edu.agh.apdvbackend.models.body_models.field.FieldResponseBody;
+import pl.edu.agh.apdvbackend.models.database.FieldType;
+import pl.edu.agh.apdvbackend.models.database.Unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+class FieldResponseBodyMapperTest {
+
+    @Autowired
+    private FieldResponseBodyMapper fieldResponseBodyMapper;
+
+    @Test
+    void ShouldMapToResponseBody() {
+        final var id = 42L;
+        final var label = "label";
+        final var fieldType = FieldType.STRING;
+        final var unit = mock(Unit.class);
+        final var field = FieldFakes
+                .builder()
+                .id(id)
+                .label(label)
+                .fieldType(fieldType)
+                .unit(unit)
+                .build();
+        final var expected = new FieldResponseBody(id, label, fieldType, unit);
+
+        final var result = fieldResponseBodyMapper.toResponseBody(field);
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void ShouldMapToResponseBodyList() {
+        final var id = 42L;
+        final var label = "label";
+        final var fieldType = FieldType.STRING;
+        final var unit = mock(Unit.class);
+        final var field = FieldFakes
+                .builder()
+                .id(id)
+                .label(label)
+                .fieldType(fieldType)
+                .unit(unit)
+                .build();
+        final var expected = List.of(new FieldResponseBody(id, label, fieldType, unit));
+
+        final var result = fieldResponseBodyMapper.toResponseBodyList(List.of(field));
+
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
Co zrobiłem :tada: 
- Naprawiłem usuwanie `Endpointa`,
- Naprawiłem usuwanie `Field` (nie jest to najlepsze rozwiązanie, bo ręcznie usuwamy elementy z `Endpointów` i `GroupEndpointów`, ale działa :sweat_smile: ),
- Naprawiłem usuwanie `FieldParser`,
- W API do `Fieldów`, zmieniłem zwracany obiekt na `FieldResponseBody` (powinno mieć taką samą strukturę jak wcześniej `Field`, ale upewnijcie się jeszcze).