### PR TITLE
APDV-XXXX Dodanie permissiona Internetu do Manifestu

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="pl.edu.agh.adpv_frontend">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
    <application
         android:label="adpv_frontend"
         android:name="${applicationName}"


### PR DESCRIPTION
Podczas budowania wersji releasowej zauważyłem, że nie ma dodanego permissiona do połączenia z internetem, przez co aplikacja nie mogła połączyć się z backendem. Tutaj szybki fix tego :dash: 